### PR TITLE
微信支付时不对传入金额进行*100操作

### DIFF
--- a/src/Gateways/Wechat/Wechat.php
+++ b/src/Gateways/Wechat/Wechat.php
@@ -84,8 +84,8 @@ abstract class Wechat implements GatewayInterface
     public function refund($config_biz = [])
     {
         $this->config = array_merge($this->config, $config_biz);
-        $this->config['total_fee'] = intval($this->config['total_fee'] * 100);
-        $this->config['refund_fee'] = intval($this->config['refund_fee'] * 100);
+        $this->config['total_fee'] = $this->config['total_fee'];
+        $this->config['refund_fee'] = $this->config['refund_fee'];
         $this->config['op_user_id'] = isset($this->config['op_user_id']) ?: $this->user_config->get('mch_id', '');
 
         $this->unsetTradeTypeAndNotifyUrl();
@@ -168,7 +168,7 @@ abstract class Wechat implements GatewayInterface
     protected function preOrder($config_biz = [])
     {
         $this->config = array_merge($this->config, $config_biz);
-        $this->config['total_fee'] = intval($this->config['total_fee'] * 100);
+        $this->config['total_fee'] = $this->config['total_fee'];
 
         return $this->getResult($this->gateway);
     }


### PR DESCRIPTION
**此次为不兼容的修改！**

现有版本会直接对传入的金额进行`*100`操作转换为分，意味着传入金额的单位为元，且有可能为带小数的浮点数。
一旦出现浮点数，那么`intval($this->config['total_fee'] * 100)`这样的操作就是不安全的，至少也要使用bcmath等扩展保证浮点数操作的准确性。
所以希望直接按照微信API的要求，不要对外封装成使用元为单位。