### PR TITLE
微信mp方式改timeStamp参数为字符串

### DIFF
--- a/src/Gateways/Wechat/MpGateway.php
+++ b/src/Gateways/Wechat/MpGateway.php
@@ -35,7 +35,7 @@ class MpGateway extends Wechat
 
         $payRequest = [
             'appId'     => $this->user_config->get('app_id'),
-            'timeStamp' => time() + '',
+            'timeStamp' => time() . '',
             'nonceStr'  => $this->createNonceStr(),
             'package'   => 'prepay_id='.$this->preOrder($config_biz)['prepay_id'],
             'signType'  => 'MD5',

--- a/src/Gateways/Wechat/MpGateway.php
+++ b/src/Gateways/Wechat/MpGateway.php
@@ -35,7 +35,7 @@ class MpGateway extends Wechat
 
         $payRequest = [
             'appId'     => $this->user_config->get('app_id'),
-            'timeStamp' => time(),
+            'timeStamp' => time() + '',
             'nonceStr'  => $this->createNonceStr(),
             'package'   => 'prepay_id='.$this->preOrder($config_biz)['prepay_id'],
             'signType'  => 'MD5',


### PR DESCRIPTION
在iphone中，新版新版的JSAPI会提示 “微信支付调用JSAPI缺少参数：timeStamp”，原因是timeStamp要求必须是字符串格式