### PR TITLE
support multi-region endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ $config_biz = [
 
 $config = [
     'wechat' => [
+        'endpoint_url' => 'https://apihk.mch.weixin.qq.com/', // optional, default 'https://api.mch.weixin.qq.com/'
         'app_id' => '',             // 公众号APPID
         'mch_id' => '',             // 微信商户号
         'notify_url' => '',

--- a/src/Gateways/Wechat/PosGateway.php
+++ b/src/Gateways/Wechat/PosGateway.php
@@ -9,7 +9,7 @@ class PosGateway extends Wechat
     /**
      * @var string
      */
-    protected $gateway = 'https://api.mch.weixin.qq.com/pay/micropay';
+    protected $gateway_order = 'pay/micropay';
 
     /**
      * get trade type config.

--- a/src/Gateways/Wechat/TransferGateway.php
+++ b/src/Gateways/Wechat/TransferGateway.php
@@ -53,7 +53,7 @@ class TransferGateway extends Wechat
         $this->config['sign'] = $this->getSign($this->config);
 
         $data = $this->fromXml($this->post(
-            $this->endpoint . $this->gateway_transfer,
+            $this->endpoint.$this->gateway_transfer,
             $this->toXml($this->config),
             [
                 'cert'    => $this->user_config->get('cert_client', ''),

--- a/src/Gateways/Wechat/TransferGateway.php
+++ b/src/Gateways/Wechat/TransferGateway.php
@@ -10,7 +10,7 @@ class TransferGateway extends Wechat
     /**
      * @var string
      */
-    protected $gateway = 'https://api.mch.weixin.qq.com/mmpaymkttransfers/promotion/transfers';
+    protected $gateway_transfer = 'mmpaymkttransfers/promotion/transfers';
 
     /**
      * get trade type config.
@@ -53,7 +53,7 @@ class TransferGateway extends Wechat
         $this->config['sign'] = $this->getSign($this->config);
 
         $data = $this->fromXml($this->post(
-            $this->gateway,
+            $this->endpoint . $this->gateway_transfer,
             $this->toXml($this->config),
             [
                 'cert'    => $this->user_config->get('cert_client', ''),

--- a/src/Gateways/Wechat/Wechat.php
+++ b/src/Gateways/Wechat/Wechat.php
@@ -15,22 +15,27 @@ abstract class Wechat implements GatewayInterface
     /**
      * @var string
      */
-    protected $gateway = 'https://api.mch.weixin.qq.com/pay/unifiedorder';
+    protected $endpoint = 'https://api.mch.weixin.qq.com/';
 
     /**
      * @var string
      */
-    protected $gateway_query = 'https://api.mch.weixin.qq.com/pay/orderquery';
+    protected $gateway_order = 'pay/unifiedorder';
 
     /**
      * @var string
      */
-    protected $gateway_close = 'https://api.mch.weixin.qq.com/pay/closeorder';
+    protected $gateway_query = 'pay/orderquery';
 
     /**
      * @var string
      */
-    protected $gateway_refund = 'https://api.mch.weixin.qq.com/secapi/pay/refund';
+    protected $gateway_close = 'pay/closeorder';
+
+    /**
+     * @var string
+     */
+    protected $gateway_refund = 'secapi/pay/refund';
 
     /**
      * @var array
@@ -61,6 +66,10 @@ abstract class Wechat implements GatewayInterface
             'notify_url' => $this->user_config->get('notify_url', ''),
             'trade_type' => $this->getTradeType(),
         ];
+
+        if ($endpoint = $this->user_config->get('endpoint_url')) {
+            $this->endpoint = $endpoint;
+        }
     }
 
     /**
@@ -167,7 +176,7 @@ abstract class Wechat implements GatewayInterface
     {
         $this->config = array_merge($this->config, $config_biz);
 
-        return $this->getResult($this->gateway);
+        return $this->getResult($this->gateway_order);
     }
 
     /**
@@ -175,18 +184,18 @@ abstract class Wechat implements GatewayInterface
      *
      * @author yansongda <me@yansongda.cn>
      *
-     * @param string $end_point
+     * @param string $path
      * @param bool   $cert
      *
      * @return array
      */
-    protected function getResult($end_point, $cert = false)
+    protected function getResult($path, $cert = false)
     {
         $this->config['sign'] = $this->getSign($this->config);
 
         if ($cert) {
             $data = $this->fromXml($this->post(
-                $end_point,
+                $this->endpoint . $path,
                 $this->toXml($this->config),
                 [
                     'cert'    => $this->user_config->get('cert_client', ''),
@@ -194,7 +203,7 @@ abstract class Wechat implements GatewayInterface
                 ]
             ));
         } else {
-            $data = $this->fromXml($this->post($end_point, $this->toXml($this->config)));
+            $data = $this->fromXml($this->post($this->endpoint . $path, $this->toXml($this->config)));
         }
 
         if (!isset($data['return_code']) || $data['return_code'] !== 'SUCCESS' || $data['result_code'] !== 'SUCCESS') {

--- a/src/Gateways/Wechat/Wechat.php
+++ b/src/Gateways/Wechat/Wechat.php
@@ -195,7 +195,7 @@ abstract class Wechat implements GatewayInterface
 
         if ($cert) {
             $data = $this->fromXml($this->post(
-                $this->endpoint . $path,
+                $this->endpoint.$path,
                 $this->toXml($this->config),
                 [
                     'cert'    => $this->user_config->get('cert_client', ''),
@@ -203,7 +203,7 @@ abstract class Wechat implements GatewayInterface
                 ]
             ));
         } else {
-            $data = $this->fromXml($this->post($this->endpoint . $path, $this->toXml($this->config)));
+            $data = $this->fromXml($this->post($this->endpoint.$path, $this->toXml($this->config)));
         }
 
         if (!isset($data['return_code']) || $data['return_code'] !== 'SUCCESS' || $data['result_code'] !== 'SUCCESS') {


### PR DESCRIPTION
Based on the documentation of WeChatPay for endpoint in different regions ([Here](https://pay.weixin.qq.com/wiki/doc/api/external/jsapi.php?chapter=9_1))

It should be able to support in different endpoint for different region in order to use WeChatPay properly.

```php
$config = [
    'endpoint_url' => '', // optional for other region which is not in china.
];
```