### PR TITLE
对微信服务商的支持

### DIFF
--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -70,7 +70,7 @@ class Wechat implements GatewayApplicationInterface
     public function __construct(Config $config)
     {
         $this->config = $config;
-        $this->mode = $this->config->get('mode', Wechat::MODE_NORMAL);
+        $this->mode = $this->config->get('mode', self::MODE_NORMAL);
         $this->gateway = Support::baseUri($this->mode);
         $this->payload = [
             'appid'            => $this->config->get('app_id', ''),

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -27,12 +27,24 @@ use Yansongda\Supports\Str;
  */
 class Wechat implements GatewayApplicationInterface
 {
+    const MODE_NORMAL = 'normal'; // 普通模式
+    const MODE_DEV = 'dev'; // 沙箱模式
+    const MODE_HK = 'hk'; // 香港钱包
+    const MODE_SERVICE = 'service'; // 服务商
+
     /**
      * Config.
      *
      * @var Config
      */
     protected $config;
+
+    /**
+     * Mode.
+     *
+     * @var string
+     */
+    protected $mode;
 
     /**
      * Wechat payload.
@@ -58,7 +70,8 @@ class Wechat implements GatewayApplicationInterface
     public function __construct(Config $config)
     {
         $this->config = $config;
-        $this->gateway = Support::baseUri($this->config->get('mode', 'normal'));
+        $this->mode = $this->config->get('mode', Wechat::MODE_NORMAL);
+        $this->gateway = Support::baseUri($this->mode);
         $this->payload = [
             'appid'            => $this->config->get('app_id', ''),
             'mch_id'           => $this->config->get('mch_id', ''),
@@ -68,6 +81,13 @@ class Wechat implements GatewayApplicationInterface
             'trade_type'       => '',
             'spbill_create_ip' => Request::createFromGlobals()->getClientIp(),
         ];
+
+        if ($this->mode === static::MODE_SERVICE) {
+            $this->payload = array_merge($this->payload, [
+                'sub_mch_id' => $this->config->get('sub_mch_id'),
+                'sub_appid'  => $this->config->get('sub_app_id', ''),
+            ]);
+        }
     }
 
     /**

--- a/src/Gateways/Wechat/AppGateway.php
+++ b/src/Gateways/Wechat/AppGateway.php
@@ -4,6 +4,7 @@ namespace Yansongda\Pay\Gateways\Wechat;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Str;
 
@@ -23,10 +24,13 @@ class AppGateway extends Gateway
     {
         $payload['appid'] = $this->config->get('appid');
         $payload['trade_type'] = $this->getTradeType();
+        if ($this->mode === Wechat::MODE_SERVICE) {
+            $payload['sub_appid'] = $this->config->get('sub_appid');
+        }
 
         $payRequest = [
             'appid'     => $payload['appid'],
-            'partnerid' => $payload['mch_id'],
+            'partnerid' => $this->mode === Wechat::MODE_SERVICE ? $payload['sub_mch_id'] : $payload['mch_id'],
             'prepayid'  => $this->preOrder('pay/unifiedorder', $payload)->prepay_id,
             'timestamp' => strval(time()),
             'noncestr'  => Str::random(),

--- a/src/Gateways/Wechat/Gateway.php
+++ b/src/Gateways/Wechat/Gateway.php
@@ -3,6 +3,7 @@
 namespace Yansongda\Pay\Gateways\Wechat;
 
 use Yansongda\Pay\Contracts\GatewayInterface;
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
@@ -17,6 +18,13 @@ abstract class Gateway implements GatewayInterface
     protected $config;
 
     /**
+     * Mode.
+     *
+     * @var string
+     */
+    protected $mode;
+
+    /**
      * Bootstrap.
      *
      * @author yansongda <me@yansongda.cn>
@@ -26,6 +34,7 @@ abstract class Gateway implements GatewayInterface
     public function __construct(Config $config)
     {
         $this->config = $config;
+        $this->mode = $this->config->get('mode', Wechat::MODE_NORMAL);
     }
 
     /**

--- a/src/Gateways/Wechat/GroupRedpackGateway.php
+++ b/src/Gateways/Wechat/GroupRedpackGateway.php
@@ -2,6 +2,7 @@
 
 namespace Yansongda\Pay\Gateways\Wechat;
 
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Collection;
 
@@ -20,6 +21,9 @@ class GroupRedpackGateway extends Gateway
     public function pay($endpoint, array $payload): Collection
     {
         $payload['wxappid'] = $payload['appid'];
+        if ($this->mode === Wechat::MODE_SERVICE) {
+            $payload['msgappid'] = $payload['appid'];
+        }
         $payload['amt_type'] = 'ALL_RAND';
 
         unset($payload['appid'], $payload['trade_type'], $payload['notify_url'], $payload['spbill_create_ip']);

--- a/src/Gateways/Wechat/MiniappGateway.php
+++ b/src/Gateways/Wechat/MiniappGateway.php
@@ -2,6 +2,7 @@
 
 namespace Yansongda\Pay\Gateways\Wechat;
 
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Supports\Collection;
 
 class MiniappGateway extends MpGateway
@@ -19,6 +20,9 @@ class MiniappGateway extends MpGateway
     public function pay($endpoint, array $payload): Collection
     {
         $payload['appid'] = $this->config->get('miniapp_id');
+        if ($this->mode === Wechat::MODE_SERVICE) {
+            $payload['sub_appid'] = $this->config->get('sub_miniapp_id');
+        }
 
         return parent::pay($endpoint, $payload);
     }

--- a/src/Gateways/Wechat/RedpackGateway.php
+++ b/src/Gateways/Wechat/RedpackGateway.php
@@ -3,6 +3,7 @@
 namespace Yansongda\Pay\Gateways\Wechat;
 
 use Symfony\Component\HttpFoundation\Request;
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Collection;
 
@@ -21,6 +22,9 @@ class RedpackGateway extends Gateway
     public function pay($endpoint, array $payload): Collection
     {
         $payload['wxappid'] = $payload['appid'];
+        if ($this->mode === Wechat::MODE_SERVICE) {
+           $payload['msgappid'] = $payload['appid'];
+        }
         $payload['client_ip'] = Request::createFromGlobals()->server->get('SERVER_ADDR');
 
         unset($payload['appid'], $payload['trade_type'], $payload['notify_url'], $payload['spbill_create_ip']);

--- a/src/Gateways/Wechat/RedpackGateway.php
+++ b/src/Gateways/Wechat/RedpackGateway.php
@@ -23,7 +23,7 @@ class RedpackGateway extends Gateway
     {
         $payload['wxappid'] = $payload['appid'];
         if ($this->mode === Wechat::MODE_SERVICE) {
-           $payload['msgappid'] = $payload['appid'];
+            $payload['msgappid'] = $payload['appid'];
         }
         $payload['client_ip'] = Request::createFromGlobals()->server->get('SERVER_ADDR');
 

--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -105,7 +105,7 @@ class Support
         $payload['appid'] = $config->get($type, '');
         $mode = $config->get('mode', Wechat::MODE_NORMAL);
         if ($mode === Wechat::MODE_SERVICE) {
-           $payload['sub_appid'] = $config->get('sub_' . $type, '');
+            $payload['sub_appid'] = $config->get('sub_'.$type, '');
         }
 
         unset($payload['notify_url'], $payload['trade_type'], $payload['type']);

--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -5,6 +5,7 @@ namespace Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Exceptions\GatewayException;
 use Yansongda\Pay\Exceptions\InvalidArgumentException;
 use Yansongda\Pay\Exceptions\InvalidSignException;
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Traits\HasHttpRequest;
@@ -209,11 +210,11 @@ class Support
     public static function baseUri($mode = null): string
     {
         switch ($mode) {
-            case 'dev':
+            case Wechat::MODE_DEV:
                 self::getInstance()->baseUri = 'https://api.mch.weixin.qq.com/sandboxnew/';
                 break;
 
-            case 'hk':
+            case Wechat::MODE_HK:
                 self::getInstance()->baseUri = 'https://apihk.mch.weixin.qq.com/';
                 break;
 

--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -103,6 +103,10 @@ class Support
         $type = isset($order['type']) ? ($order['type'].($order['type'] == 'app' ?: '_').'id') : 'app_id';
 
         $payload['appid'] = $config->get($type, '');
+        $mode = $config->get('mode', Wechat::MODE_NORMAL);
+        if ($mode === Wechat::MODE_SERVICE) {
+           $payload['sub_appid'] = $config->get('sub_' . $type, '');
+        }
 
         unset($payload['notify_url'], $payload['trade_type'], $payload['type']);
 

--- a/src/Gateways/Wechat/TransferGateway.php
+++ b/src/Gateways/Wechat/TransferGateway.php
@@ -3,6 +3,7 @@
 namespace Yansongda\Pay\Gateways\Wechat;
 
 use Symfony\Component\HttpFoundation\Request;
+use Yansongda\Pay\Gateways\Wechat;
 use Yansongda\Pay\Log;
 use Yansongda\Supports\Collection;
 
@@ -20,6 +21,9 @@ class TransferGateway extends Gateway
      */
     public function pay($endpoint, array $payload): Collection
     {
+        if ($this->mode === Wechat::MODE_SERVICE) {
+            unset($payload['sub_mch_id'], $payload['sub_appid']);
+        }
         $type = isset($payload['type']) ? ($payload['type'].($payload['type'] == 'app' ?: '_').'id') : 'app_id';
 
         $payload['mch_appid'] = $this->config->get($type, '');


### PR DESCRIPTION
麻烦看下对服务商的支持采用这种形式可以吗（基本都改了，但暂未测试）？

```php
$config = [
    'appid' => 'wxb3fxxxxxxxxxxx', // APP APPID
    'app_id' => 'wxb3fxxxxxxxxxxx', // 公众号 APPID
    'miniapp_id' => 'wxb3fxxxxxxxxxxx', // 小程序 APPID
    'sub_appid' => 'wxb3fxxxxxxxxxxx', // 子商户 APP APPID
    'sub_app_id' => 'wxb3fxxxxxxxxxxx', // 子商户 公众号 APPID
    'sub_miniapp_id' => 'wxb3fxxxxxxxxxxx', // 子商户 小程序 APPID
    'mch_id' => '146xxxxxx', // 商户号
    'sub_mch_id' => '146xxxxxx', // 子商户商户号
    'key' => '4e538260xxxxxxxxxxxxxxxxxxxxxx', // 主商户 key
    'notify_url' => 'http://yanda.net.cn/notify.php',
    'cert_client' => './cert/apiclient_cert.pem', // optional，退款等情况时用到
    'cert_key' => './cert/apiclient_key.pem',// optional，退款等情况时用到
    'log' => [ // optional
        'file' => './logs/wechat.log',
        'level' => 'debug'
    ],
    'mode' => 'service',
]
```