### PR TITLE
refactor: 更改phpdoc提示调用魔术方法时返回正确的类型提示

### DIFF
--- a/src/Gateways/Alipay.php
+++ b/src/Gateways/Alipay.php
@@ -15,12 +15,12 @@ use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
 
 /**
- * @method \Yansongda\Pay\Gateways\Alipay\AppGateway app(array $config) APP 支付
- * @method \Yansongda\Pay\Gateways\Alipay\PosGateway pos(array $config) 刷卡支付
- * @method \Yansongda\Pay\Gateways\Alipay\ScanGateway scan(array $config) 扫码支付
- * @method \Yansongda\Pay\Gateways\Alipay\TransferGateway transfer(array $config) 帐户转账
- * @method \Yansongda\Pay\Gateways\Alipay\WapGateway wap(array $config) 手机网站支付
- * @method \Yansongda\Pay\Gateways\Alipay\WebGateway web(array $config) 电脑支付
+ * @method Response app(array $config) APP 支付
+ * @method Collection pos(array $config) 刷卡支付
+ * @method Collection scan(array $config) 扫码支付
+ * @method Collection transfer(array $config) 帐户转账
+ * @method Response wap(array $config) 手机网站支付
+ * @method Response web(array $config) 电脑支付
  */
 class Alipay implements GatewayApplicationInterface
 {

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -99,12 +99,12 @@ class Support
      *
      * @author yansongda <me@yansongda.cn>
      *
-     * @param array  $parmas
+     * @param array  $params
      * @param string $privateKey
      *
      * @return string
      */
-    public static function generateSign(array $parmas, $privateKey = null): string
+    public static function generateSign(array $params, $privateKey = null): string
     {
         if (is_null($privateKey)) {
             throw new InvalidConfigException('Missing Alipay Config -- [private_key]');
@@ -118,7 +118,7 @@ class Support
                 "\n-----END RSA PRIVATE KEY-----";
         }
 
-        openssl_sign(self::getSignContent($parmas), $sign, $privateKey, OPENSSL_ALGO_SHA256);
+        openssl_sign(self::getSignContent($params), $sign, $privateKey, OPENSSL_ALGO_SHA256);
 
         return base64_encode($sign);
     }

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -16,15 +16,15 @@ use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
 
 /**
- * @method \Yansongda\Pay\Gateways\Wechat\AppGateway app(array $config) APP 支付
- * @method \Yansongda\Pay\Gateways\Wechat\GroupRedpackGateway groupRedpack(array $config) 分裂红包
- * @method \Yansongda\Pay\Gateways\Wechat\MiniappGateway miniapp(array $config) 小程序支付
- * @method \Yansongda\Pay\Gateways\Wechat\MpGateway mp(array $config) 公众号支付
- * @method \Yansongda\Pay\Gateways\Wechat\PosGateway pos(array $config) 刷卡支付
- * @method \Yansongda\Pay\Gateways\Wechat\RedpackGateway redpack(array $config) 普通红包
- * @method \Yansongda\Pay\Gateways\Wechat\ScanGateway scan(array $config) 扫码支付
- * @method \Yansongda\Pay\Gateways\Wechat\TransferGateway transfer(array $config) 企业付款
- * @method \Yansongda\Pay\Gateways\Wechat\WapGateway wap(array $config) H5 支付
+ * @method Response app(array $config) APP 支付
+ * @method Collection groupRedpack(array $config) 分裂红包
+ * @method Collection miniapp(array $config) 小程序支付
+ * @method Collection mp(array $config) 公众号支付
+ * @method Collection pos(array $config) 刷卡支付
+ * @method Collection redpack(array $config) 普通红包
+ * @method Collection scan(array $config) 扫码支付
+ * @method Collection transfer(array $config) 企业付款
+ * @method Response wap(array $config) H5 支付
  */
 class Wechat implements GatewayApplicationInterface
 {


### PR DESCRIPTION
根据源码`Alipay.php`和`Wechat.php`中`makepay($gateway)`，应该是根据每一个 gateway 的 pay 方法的返回值类型确定每个魔术调用的返回值类型。

```php
protected function makePay($gateway)
{
    $app = new $gateway($this->config);

    if ($app instanceof GatewayInterface) {
        return $app->pay($this->gateway, $this->payload);
    }

    throw new InvalidGatewayException("Pay Gateway [{$gateway}] Must Be An Instance Of GatewayInterface");
}
```
