### PR TITLE
Fixed issues caused by Laravel-S

### DIFF
--- a/src/Gateways/Alipay.php
+++ b/src/Gateways/Alipay.php
@@ -149,7 +149,7 @@ class Alipay implements GatewayApplicationInterface
     public function verify($data = null, $refund = false): Collection
     {
         if (is_null($data)) {
-            $request = Request::createFromGlobals();
+            $request = (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals());
 
             $data = $request->request->count() > 0 ? $request->request->all() : $request->query->all();
             $data = Support::encoding($data, 'utf-8', $data['charset'] ?? 'gb2312');

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -91,7 +91,7 @@ class Wechat implements GatewayApplicationInterface
             'notify_url'       => $config->get('notify_url', ''),
             'sign'             => '',
             'trade_type'       => '',
-            'spbill_create_ip' => Request::createFromGlobals()->getClientIp(),
+            'spbill_create_ip' => (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals())->getClientIp(),
         ];
 
         if ($config->get('mode', self::MODE_NORMAL) === static::MODE_SERVICE) {
@@ -161,7 +161,7 @@ class Wechat implements GatewayApplicationInterface
      */
     public function verify($content = null, $refund = false): Collection
     {
-        $content = $content ?? Request::createFromGlobals()->getContent();
+        $content = $content ?? (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals())->getContent();
 
         Log::info('Received Wechat Request', [$content]);
 

--- a/src/Gateways/Wechat/RedpackGateway.php
+++ b/src/Gateways/Wechat/RedpackGateway.php
@@ -28,7 +28,7 @@ class RedpackGateway extends Gateway
         $payload['wxappid'] = $payload['appid'];
 
         if (php_sapi_name() !== 'cli') {
-            $payload['client_ip'] = Request::createFromGlobals()->server->get('SERVER_ADDR');
+            $payload['client_ip'] = (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals())->server->get('SERVER_ADDR');
         }
 
         if ($this->mode !== Wechat::MODE_SERVICE) {

--- a/src/Gateways/Wechat/ScanGateway.php
+++ b/src/Gateways/Wechat/ScanGateway.php
@@ -24,7 +24,7 @@ class ScanGateway extends Gateway
      */
     public function pay($endpoint, array $payload): Collection
     {
-        $payload['spbill_create_ip'] = Request::createFromGlobals()->server->get('SERVER_ADDR');
+        $payload['spbill_create_ip'] = (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals())->server->get('SERVER_ADDR');
         $payload['trade_type'] = $this->getTradeType();
 
         Log::info('Starting To Pay A Wechat Scan Order', [$endpoint, $payload]);

--- a/src/Gateways/Wechat/TransferGateway.php
+++ b/src/Gateways/Wechat/TransferGateway.php
@@ -35,7 +35,7 @@ class TransferGateway extends Gateway
         $payload['mchid'] = $payload['mch_id'];
 
         if (php_sapi_name() !== 'cli') {
-            $payload['spbill_create_ip'] = Request::createFromGlobals()->server->get('SERVER_ADDR');
+            $payload['spbill_create_ip'] = (php_sapi_name() == 'cli' ? request() : Request::createFromGlobals())->server->get('SERVER_ADDR');
         }
 
         unset($payload['appid'], $payload['mch_id'], $payload['trade_type'],


### PR DESCRIPTION
使用Laravel-S时 应用的运行环境是cli中的swoole服务端. 不能读取到$_POST等全局变量,CreateFromGlobals 也就没有作用