### PR TITLE
服务商模式错误以及微信小程序服务商模式支付的错误

### DIFF
--- a/src/Gateways/Wechat/AppGateway.php
+++ b/src/Gateways/Wechat/AppGateway.php
@@ -30,7 +30,7 @@ class AppGateway extends Gateway
         $payload['appid'] = Support::getInstance()->appid;
         $payload['trade_type'] = $this->getTradeType();
 
-        if ($this->mode !== Wechat::MODE_SERVICE) {
+        if ($this->mode === Wechat::MODE_SERVICE) {
             $payload['sub_appid'] = Support::getInstance()->sub_appid;
         }
 

--- a/src/Gateways/Wechat/GroupRedpackGateway.php
+++ b/src/Gateways/Wechat/GroupRedpackGateway.php
@@ -27,7 +27,9 @@ class GroupRedpackGateway extends Gateway
         $payload['wxappid'] = $payload['appid'];
         $payload['amt_type'] = 'ALL_RAND';
 
-        $this->mode !== Wechat::MODE_SERVICE ?: $payload['msgappid'] = $payload['appid'];
+        if ($this->mode === Wechat::MODE_SERVICE) {
+            $payload['msgappid'] = $payload['appid'];
+        }
 
         unset($payload['appid'], $payload['trade_type'],
               $payload['notify_url'], $payload['spbill_create_ip']);

--- a/src/Gateways/Wechat/MiniappGateway.php
+++ b/src/Gateways/Wechat/MiniappGateway.php
@@ -25,8 +25,9 @@ class MiniappGateway extends MpGateway
     {
         $payload['appid'] = Support::getInstance()->miniapp_id;
 
-        if ($this->mode !== Wechat::MODE_SERVICE) {
+        if ($this->mode === Wechat::MODE_SERVICE) {
             $payload['sub_appid'] = Support::getInstance()->sub_miniapp_id;
+            $this->payRequestUseSubAppId = true;
         }
 
         return parent::pay($endpoint, $payload);

--- a/src/Gateways/Wechat/MpGateway.php
+++ b/src/Gateways/Wechat/MpGateway.php
@@ -8,6 +8,12 @@ use Yansongda\Supports\Str;
 
 class MpGateway extends Gateway
 {
+
+    /**
+     * @var bool
+     */
+    protected $payRequestUseSubAppId = false;
+
     /**
      * Pay an order.
      *
@@ -28,7 +34,7 @@ class MpGateway extends Gateway
         $payload['trade_type'] = $this->getTradeType();
 
         $pay_request = [
-            'appId'     => $payload['appid'],
+            'appId'     => !$this->payRequestUseSubAppId ? $payload['appid'] : $payload['sub_appid'],
             'timeStamp' => strval(time()),
             'nonceStr'  => Str::random(),
             'package'   => 'prepay_id='.$this->preOrder($payload)->prepay_id,

--- a/src/Gateways/Wechat/MpGateway.php
+++ b/src/Gateways/Wechat/MpGateway.php
@@ -8,7 +8,6 @@ use Yansongda\Supports\Str;
 
 class MpGateway extends Gateway
 {
-
     /**
      * @var bool
      */


### PR DESCRIPTION
1. 小程序支付发起 appId必须是发起支付的小程序的appid，服务商模式下为 sub_mini_appid

[小程序调起支付API](https://pay.weixin.qq.com/wiki/doc/api/wxa/wxa_sl_api.php?chapter=7_7&index=5)

2. 原来判断服务商的代码判断改错了。。。

原来
```php
$this->mode !== Wechat::MODE_SERVICE ?: $payload['sub_appid'] = $this->config->get('sub_miniapp_id');
```

正确的应该是等于服务商模式的时候才需要 sub_appid