### PR TITLE
调整因WAP(H5)支付注解中返回类型错误

### DIFF
--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -3,8 +3,8 @@
 namespace Yansongda\Pay\Gateways;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Yansongda\Pay\Contracts\GatewayApplicationInterface;
 use Yansongda\Pay\Contracts\GatewayInterface;
 use Yansongda\Pay\Exceptions\GatewayException;

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -2,9 +2,9 @@
 
 namespace Yansongda\Pay\Gateways;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Yansongda\Pay\Contracts\GatewayApplicationInterface;
 use Yansongda\Pay\Contracts\GatewayInterface;
 use Yansongda\Pay\Exceptions\GatewayException;

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -3,8 +3,8 @@
 namespace Yansongda\Pay\Gateways;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 use Yansongda\Pay\Contracts\GatewayApplicationInterface;
 use Yansongda\Pay\Contracts\GatewayInterface;
 use Yansongda\Pay\Exceptions\GatewayException;

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -4,6 +4,7 @@ namespace Yansongda\Pay\Gateways;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Yansongda\Pay\Contracts\GatewayApplicationInterface;
 use Yansongda\Pay\Contracts\GatewayInterface;
 use Yansongda\Pay\Exceptions\GatewayException;
@@ -24,7 +25,7 @@ use Yansongda\Supports\Str;
  * @method Collection redpack(array $config) 普通红包
  * @method Collection scan(array $config) 扫码支付
  * @method Collection transfer(array $config) 企业付款
- * @method Response wap(array $config) H5 支付
+ * @method RedirectResponse wap(array $config) H5 支付
  */
 class Wechat implements GatewayApplicationInterface
 {

--- a/src/Gateways/Wechat/WapGateway.php
+++ b/src/Gateways/Wechat/WapGateway.php
@@ -20,7 +20,7 @@ class WapGateway extends Gateway
      * @throws \Yansongda\Pay\Exceptions\InvalidArgumentException
      * @throws \Yansongda\Pay\Exceptions\InvalidSignException
      *
-     * @return Response
+     * @return RedirectResponse
      */
     public function pay($endpoint, array $payload): Response
     {

--- a/src/Gateways/Wechat/WapGateway.php
+++ b/src/Gateways/Wechat/WapGateway.php
@@ -3,7 +3,6 @@
 namespace Yansongda\Pay\Gateways\Wechat;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Yansongda\Pay\Log;
 
 class WapGateway extends Gateway

--- a/src/Gateways/Wechat/WapGateway.php
+++ b/src/Gateways/Wechat/WapGateway.php
@@ -22,7 +22,7 @@ class WapGateway extends Gateway
      *
      * @return RedirectResponse
      */
-    public function pay($endpoint, array $payload): Response
+    public function pay($endpoint, array $payload): RedirectResponse
     {
         $payload['trade_type'] = $this->getTradeType();
 


### PR DESCRIPTION
因返回值类型标注错误导致IDE无法正确提示。
- 调整前
![image](https://user-images.githubusercontent.com/31845646/49355394-4f771680-f702-11e8-9084-3e4dee71b9a7.png)

-  调整后
![image](https://user-images.githubusercontent.com/31845646/49355399-59007e80-f702-11e8-80b4-3d98c0097df9.png)
