### PR TITLE
修复alipay URL错误

### DIFF
--- a/src/Gateways/Alipay.php
+++ b/src/Gateways/Alipay.php
@@ -41,8 +41,8 @@ class Alipay implements GatewayApplicationInterface
      * Const url.
      */
     const URL = [
-        self::MODE_NORMAL => 'https://openapi.alipay.com/gateway.do?charset=utf-8',
-        self::MODE_DEV    => 'https://openapi.alipaydev.com/gateway.do?charset=utf-8',
+        self::MODE_NORMAL => 'https://openapi.alipay.com/gateway.do',
+        self::MODE_DEV    => 'https://openapi.alipaydev.com/gateway.do',
     ];
 
     /**


### PR DESCRIPTION
URL常量中添加?charset=utf-8会导致生成的URL中出现https://openapi.alipay.com/gateway.do?charset=utf-8?app_id=xxx的错误，导致访问失败。
例如生成的URL：https://openapi.alipay.com/gateway.do?charset=utf-8?app_id=2019071165855011&format=JSON&charset=utf-8&sign_type=RSA2&version=1.0&notify_url=http%3A%2F%2Fdev.quncloud.net%2Fcallback%2Fweb&timestamp=2019-07-20+11%3A48%3A52&biz_content=%7B%22total_amount%22%3A%221000%22%2C%22subject%22%3A%22%5Cu5e7f%5Cu544a%5Cu4e3b%5Cu5145%5Cu503c1000%5Cu5143%22%2C%22out_trade_no%22%3A626549201102176256%2C%22product_code%22%3A%22FAST_INSTANT_TRADE_PAY%22%7D&method=alipay.trade.page.pay&sign=kCjxN1gYkWlVhr089JdL%2Bjy5odc6Onq3efRjbfbPhDVMQsv8yv1h42fzt%2BN6ZyfzIOfJgdZ81FXxoSysmekvXtfIb2UgLKE%2BOGvui5U3fzaIIh%2FbX5Fh1gnCd2z6Ne8sGS4jE9KI111%2F8QH%2BCKdhircmwf6QfJPU4dw4o5qVxOKuyxjRCbAePZyR05rRnBEOhLUf5e5s6xPI9R%2FafZdaxmdYQVh7DZoyq%2BiZMuiNvmrwwbybtlkC6msjVdNSNxJlitlCI%2BxiijRLS0WSqDUDeoF2qCzPwnl7FRl42a%2Fz4Eu7sC1DqIDfrbZNiKPPeqDV56yhEESW6jQPasDCyEdYvw%3D%3D