### PR TITLE
fix: 参数过滤

### DIFF
--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -256,7 +256,7 @@ class Support
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {
-            if ($verify && 'sign' != $k && 'sign_type' != $k) {
+            if ($verify && $k != 'sign' && $k != 'sign_type' && $k != 's') {
                 $stringToBeSigned .= $k.'='.$v.'&';
             }
             if (!$verify && '' !== $v && !is_null($v) && 'sign' != $k && '@' != substr($v, 0, 1)) {


### PR DESCRIPTION
过滤 $data 数组中的 s 参数，导致验签失败的问题。