### PR TITLE
撤销订单接口，不需要notify_url参数

### DIFF
--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -272,7 +272,7 @@ class Wechat implements GatewayApplicationInterface
      */
     public function cancel($order): Collection
     {
-        unset($this->payload['spbill_create_ip'],$this->payload['notify_url']);
+        unset($this->payload['spbill_create_ip'], $this->payload['notify_url']);
         
         $this->payload = Support::filterPayload($this->payload, $order, true);
 

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -272,9 +272,7 @@ class Wechat implements GatewayApplicationInterface
      */
     public function cancel($order): Collection
     {
-        unset($this->payload['spbill_create_ip']);
-        
-        unset($this->payload['notify_url']);
+        unset($this->payload['spbill_create_ip'],$this->payload['notify_url']);
         
         $this->payload = Support::filterPayload($this->payload, $order, true);
 

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -273,7 +273,7 @@ class Wechat implements GatewayApplicationInterface
     public function cancel($order): Collection
     {
         unset($this->payload['spbill_create_ip']);
-
+        unset($this->payload['notify_url']);
         $this->payload = Support::filterPayload($this->payload, $order, true);
 
         Events::dispatch(new Events\MethodCalled('Wechat', 'Cancel', $this->gateway, $this->payload));

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -273,7 +273,9 @@ class Wechat implements GatewayApplicationInterface
     public function cancel($order): Collection
     {
         unset($this->payload['spbill_create_ip']);
+        
         unset($this->payload['notify_url']);
+        
         $this->payload = Support::filterPayload($this->payload, $order, true);
 
         Events::dispatch(new Events\MethodCalled('Wechat', 'Cancel', $this->gateway, $this->payload));


### PR DESCRIPTION
要不请求不成功 ,报错Result Of Wechat Api {"return_code":"FAIL","return_msg":"不识别的参数notify_url"}