### PR TITLE
perf(support php7.4): Handles bcmath floating point Numbers

### DIFF
--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -446,6 +446,6 @@ class Support
             }
         }
 
-        return $dec;
+        return str_replace('.00', '', $dec);
     }
 }


### PR DESCRIPTION
处理 PHP7.1 之后 bcmath 函数库自带浮点数导致 SN md5 加密不一致