### PR TITLE
fix alipay RETURN method Sign Verify FAILED

### DIFF
--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -238,10 +238,12 @@ class Support
     public static function getSignContent(array $data, $verify = false): string
     {
         ksort($data);
+        
+        $isReturn = array_key_exists('method', $data) && $data['method'] == 'alipay.trade.page.pay.return';
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {
-            if ($verify && 'sign' != $k && 'sign_type' != $k) {
+            if ($verify && 'sign' != $k && ('sign_type' != $k || $isReturn)) {
                 $stringToBeSigned .= $k.'='.$v.'&';
             }
             if (!$verify && '' !== $v && !is_null($v) && 'sign' != $k && '@' != substr($v, 0, 1)) {

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -239,7 +239,7 @@ class Support
     {
         ksort($data);
         
-        $isReturn = array_key_exists('method', $data) && $data['method'] == 'alipay.trade.page.pay.return';
+        $isReturn = array_key_exists('method', $data) && 'alipay.trade.page.pay.return' == $data['method'];
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -238,7 +238,7 @@ class Support
     public static function getSignContent(array $data, $verify = false): string
     {
         ksort($data);
-        
+
         $isReturn = array_key_exists('method', $data) && 'alipay.trade.page.pay.return' == $data['method'];
 
         $stringToBeSigned = '';

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -239,7 +239,7 @@ class Support
     {
         ksort($data);
 
-        $isDevModeReturn = self::$instance->mode == Alipay::MODE_DEV && array_key_exists('method', $data) && (in_array($data['method'], ['alipay.trade.page.pay.return', 'alipay.trade.wap.pay.return']));
+        $isDevModeReturn = Alipay::MODE_DEV == self::$instance->mode && array_key_exists('method', $data) && (in_array($data['method'], ['alipay.trade.page.pay.return', 'alipay.trade.wap.pay.return']));
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -239,11 +239,11 @@ class Support
     {
         ksort($data);
 
-        $isReturn = array_key_exists('method', $data) && (in_array($data['method'], ['alipay.trade.page.pay.return', 'alipay.trade.wap.pay.return']));
+        $isDevModeReturn = self::$instance->mode == Alipay::MODE_DEV && array_key_exists('method', $data) && (in_array($data['method'], ['alipay.trade.page.pay.return', 'alipay.trade.wap.pay.return']));
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {
-            if ($verify && 'sign' != $k && ('sign_type' != $k || $isReturn)) {
+            if ($verify && 'sign' != $k && ('sign_type' != $k || $isDevModeReturn)) {
                 $stringToBeSigned .= $k.'='.$v.'&';
             }
             if (!$verify && '' !== $v && !is_null($v) && 'sign' != $k && '@' != substr($v, 0, 1)) {

--- a/src/Gateways/Alipay/Support.php
+++ b/src/Gateways/Alipay/Support.php
@@ -239,7 +239,7 @@ class Support
     {
         ksort($data);
 
-        $isReturn = array_key_exists('method', $data) && 'alipay.trade.page.pay.return' == $data['method'];
+        $isReturn = array_key_exists('method', $data) && (in_array($data['method'], ['alipay.trade.page.pay.return', 'alipay.trade.wap.pay.return']));
 
         $stringToBeSigned = '';
         foreach ($data as $k => $v) {


### PR DESCRIPTION
fix https://github.com/yansongda/pay/issues/375 https://github.com/yansongda/pay/issues/376

支付宝的回调接口，不知为何验签要带上 `sign_type` .....
但是异步通知又要去掉 `sign_type` ..... 真实迷惑操作