### PR TITLE
Auto running php-cs-fixer to fix no standard code

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -1,24 +1,28 @@
-name: Linter
+name: Check & fix styling
+
 on: [push, pull_request]
 
 jobs:
   php_cs_fixer:
-    name: php_cs_fixer-php-${{ matrix.php }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php:
-          - 7.3
-          - 7.4
-    container:
-      image: yansongda/php-fpm:${{ matrix.php }}
     steps:
-      - name: Install Git
-        run: apt-get update && apt-get install -y git
-      - name: Checkout Code
-        uses: actions/checkout@master
-      - name: Install Dependencies
-        run: composer install --no-progress
-      - name: Run PHP-CS-Fixer
-        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff 1>&2
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Fix style
+        uses: docker://oskarstark/php-cs-fixer-ga:2.19.0
+        with:
+          args: --config=.php_cs --allow-risky=yes
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v2.3.0
+        with:
+          commit_message: Fix styling
+          branch: ${{ steps.extract_branch.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
使用修改一下工作流文件，自动化格式化代码

效果：对于提交的代码不需要开发者提前执行格式化操作，每次 push 或者 pr 代码都进行检查，对于不合格的代码进行修复并且创建一个新的提交，commit message 写为 "Fix styling"