### PR TITLE
use LIBXML_COMPACT optimize speed

### DIFF
--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -310,7 +310,7 @@ class Support
             libxml_disable_entity_loader(true);
         }
 
-        return json_decode(json_encode(simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA), JSON_UNESCAPED_UNICODE), true);
+        return json_decode(json_encode(simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_COMPACT), JSON_UNESCAPED_UNICODE), true);
     }
 
     /**


### PR DESCRIPTION
follow official php doc https://www.php.net/manual/en/libxml.constants.php
```
LIBXML_COMPACT (int)
Activate small nodes allocation optimization. This may speed up your application without needing to change the code.
Note:

Only available in Libxml >= 2.6.21
```