### PR TITLE
修复微信小程序支付的错误：支付验证签名失败

### DIFF
--- a/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
@@ -4,6 +4,21 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Plugin\Wechat\Pay\Mini;
 
+use Yansongda\Pay\Rocket;
+
 class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokePrepayPlugin
 {
+    /**
+     * @param Rocket $rocket
+     * @return string
+     * @throws \Yansongda\Pay\Exception\ContainerDependencyException
+     * @throws \Yansongda\Pay\Exception\ContainerException
+     * @throws \Yansongda\Pay\Exception\ServiceNotFoundException
+     */
+    protected function getAppid(Rocket $rocket): string
+    {
+        $config = get_wechat_config($rocket->getParams());
+
+        return $config->get('mini_app_id', '');
+    }
 }

--- a/tests/Plugin/Wechat/Mini/InvokePrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Mini/InvokePrepayPluginTest.php
@@ -18,6 +18,7 @@ class InvokePrepayPluginTest extends TestCase
         $contents = $result->getDestination();
 
         self::assertArrayHasKey('appId', $contents->all());
+        self::assertEquals('wx55955316af4ef14', $contents->get('appId'));
         self::assertArrayHasKey('nonceStr', $contents->all());
         self::assertArrayHasKey('package', $contents->all());
         self::assertArrayHasKey('signType', $contents->all());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 'default' => [
                     'mp_app_id' => 'wx55955316af4ef13',
                     'mch_id' => '1600314069',
+                    'mini_app_id' => 'wx55955316af4ef14',
                     'mch_secret_key' => '53D67FCB97E68F9998CBD17ED7A8D1E2',
                     'mch_secret_cert' => __DIR__.'/Cert/wechatAppPrivateKey.pem',
                     'mch_public_cert_path' => __DIR__.'/Cert/wechatAppPublicKey.pem',


### PR DESCRIPTION
重写 getAppid 使它正确的读取微信小程序的app id 而不是微信公众号的app id