### PR TITLE
add: 支持服务商模式收款

### DIFF
--- a/src/Plugin/Wechat/GeneralPlugin.php
+++ b/src/Plugin/Wechat/GeneralPlugin.php
@@ -8,6 +8,7 @@ use Closure;
 use Psr\Http\Message\RequestInterface;
 use Yansongda\Pay\Contract\PluginInterface;
 use Yansongda\Pay\Logger;
+use Yansongda\Pay\Pay;
 use Yansongda\Pay\Request;
 use Yansongda\Pay\Rocket;
 
@@ -67,6 +68,18 @@ abstract class GeneralPlugin implements PluginInterface
             'User-Agent' => 'yansongda/pay-v3.0.0',
             'Content-Type' => 'application/json; charset=utf-8',
         ];
+    }
+
+    /**
+     * 判断是否是服务商模式
+     */
+    protected function isServicePartnerMode($config)
+    {
+        //服务商自收款模式
+        if(isset($config['mode']) && $config['mode'] == Pay::MODE_SERVICE) {
+            return true; 
+        }
+        return false;
     }
 
     abstract protected function doSomething(Rocket $rocket): void;

--- a/src/Plugin/Wechat/Pay/App/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/App/PrepayPlugin.php
@@ -11,11 +11,20 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
 {
     protected function getUri(Rocket $rocket): string
     {
-        return 'v3/pay/transactions/app';
+        return $this->isServicePartnerMode(get_wechat_config($rocket->getParams())) 
+                ? 'v3/pay/partner/transactions/app' 
+                : 'v3/pay/transactions/app';
     }
 
     protected function getWechatId(Config $config): array
     {
+        if ($this->isServicePartnerMode($config)) {
+            return [
+                'sp_appid' => $config->get('app_id', ''),
+                'sp_mchid' => $config->get('mch_id', ''),
+            ];
+        }
+
         return [
             'appid' => $config->get('app_id', ''),
             'mchid' => $config->get('mch_id', ''),

--- a/src/Plugin/Wechat/Pay/Common/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Common/PrepayPlugin.php
@@ -12,7 +12,9 @@ class PrepayPlugin extends GeneralPlugin
 {
     protected function getUri(Rocket $rocket): string
     {
-        return 'v3/pay/transactions/jsapi';
+        return $this->isServicePartnerMode(get_wechat_config($rocket->getParams())) 
+                ? 'v3/pay/partner/transactions/jsapi' 
+                : 'v3/pay/transactions/jsapi';
     }
 
     /**
@@ -35,6 +37,13 @@ class PrepayPlugin extends GeneralPlugin
 
     protected function getWechatId(Config $config): array
     {
+        if ($this->isServicePartnerMode($config)) {
+            return [
+                'sp_appid' => $config->get('mp_app_id', ''),
+                'sp_mchid' => $config->get('mch_id', ''),
+            ];
+        }
+        
         return [
             'appid' => $config->get('mp_app_id', ''),
             'mchid' => $config->get('mch_id', ''),

--- a/src/Plugin/Wechat/Pay/Common/QueryPlugin.php
+++ b/src/Plugin/Wechat/Pay/Common/QueryPlugin.php
@@ -21,16 +21,30 @@ class QueryPlugin extends GeneralPlugin
         $config = get_wechat_config($rocket->getParams());
         $payload = $rocket->getPayload();
 
+        //服务商模式-接口uri及参数
+        if ($this->isServicePartnerMode(get_wechat_config($rocket->getParams()))) {
+            $baseUriPath = 'v3/pay/partner/transactions/';
+            //子商户支持配置文件定义和传参 var_dump($payload->all()); 
+            $subMchid = $config->get('sub_mchid', '');
+            $uriParams = [
+                'sp_mchid' => $config->get('mch_id', ''),
+                'sub_mchid' => !empty($subMchid) ? $subMchid : $payload->get('sub_mchid', '')
+            ];
+        } else {
+            $baseUriPath = 'v3/pay/transactions/';
+            $uriParams = [
+                'mchid' => $config->get('mch_id', '')
+            ];
+        }
+        
         if (!is_null($payload->get('transaction_id'))) {
-            return 'v3/pay/transactions/id/'.
-                $payload->get('transaction_id').
-                '?mchid='.$config->get('mch_id', '');
+            return $baseUriPath . 'id/' . $payload->get('transaction_id') .
+                   '?' . http_build_query($uriParams);
         }
 
         if (!is_null($payload->get('out_trade_no'))) {
-            return 'v3/pay/transactions/out-trade-no/'.
-                $payload->get('out_trade_no').
-                '?mchid='.$config->get('mch_id', '');
+            return $baseUriPath . 'out-trade-no/' . $payload->get('out_trade_no') .
+                   '?' . http_build_query($uriParams);
         }
 
         throw new InvalidParamsException(InvalidParamsException::MISSING_NECESSARY_PARAMS);

--- a/src/Plugin/Wechat/Pay/H5/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/H5/PrepayPlugin.php
@@ -10,6 +10,8 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
 {
     protected function getUri(Rocket $rocket): string
     {
-        return 'v3/pay/transactions/h5';
+        return $this->isServicePartnerMode(get_wechat_config($rocket->getParams())) 
+                ? 'v3/pay/partner/transactions/h5' 
+                : 'v3/pay/transactions/h5';
     }
 }

--- a/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
@@ -10,6 +10,13 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
 {
     protected function getWechatId(Config $config): array
     {
+        if ($this->isServicePartnerMode($config)) {
+            return [
+                'sp_appid' => $config->get('mp_app_id', ''),
+                'sp_mchid' => $config->get('mch_id', ''),
+            ];
+        }
+        
         return [
             'appid' => $config->get('mini_app_id', ''),
             'mchid' => $config->get('mch_id', ''),

--- a/src/Plugin/Wechat/Pay/Native/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Native/PrepayPlugin.php
@@ -10,6 +10,10 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
 {
     protected function getUri(Rocket $rocket): string
     {
-        return 'v3/pay/transactions/native';
+        return $this->isServicePartnerMode(get_wechat_config($rocket->getParams())) 
+                ? 'v3/pay/partner/transactions/native' 
+                : 'v3/pay/transactions/native';
     }
+
+
 }


### PR DESCRIPTION
## 一 核心修改
1. 修改JS/小程序/Native/H5/App  创建订单接口地址及传参
2. 修改JS/小程序/Native/H5/App 查询交易订单的接口地址及传参
3. 修改关闭交易的传参

## 二 配置文件微信节点新增(mode和sub_mchid)字段
```
$config = [
    ……
    'wechat' => [
        'default' => [
            // 公众号 的 app_id
            'mp_app_id' => '2016082000291234',
            // 小程序 的 app_id
            'mini_app_id' => '',
            // app 的 app_id
            'app_id' => '',
            // 必填-商户号 
            'mch_id' => '',
            // 合单 app_id
            'combine_app_id' => '',
            // 合单商户号 
            'combine_mch_id' => '',
            // 必填-商户秘钥
            'mch_secret_key' => '',
            // 必填-商户私钥
            'mch_secret_cert' => '',
            // 必填-商户公钥证书路径
            'mch_public_cert_path' => '',
            // 选填-微信公钥证书路径, optional，强烈建议 php-fpm 模式下配置此参数
            'wechat_public_cert_path' => [
                '45F59D4DABF31918AFCEC556D5D2C6E376675D57' => __DIR__.'/Cert/wechatPublicKey.crt',
            ],
            // 必填
            'notify_url' => 'https://yansongda.cn/wechat/notify',
            //子商户号
           'sub_mchid' => '',
           // 选填-默认为正常模式。可选为： MODE_NORMAL, MODE_SANDBOX, MODE_SERVICE
            'mode' => Pay::MODE_SERVICE, //服务商模式
        ]
    ],
……
];
```
### 三 关于sub_machid传参
 ```
  作为支付网关， sub_machid会存在不一很多，
  在创建交易，查询，关闭交易考虑了从配置文件和传参中双重取数逻辑
 ```
### 三 关于异步通知地址
 ```
  作为支付网关 可能同时存在普通商户(代收模式)，服务商(自收模式)
  那两种形式notify_url建议设置不同，以便于加载不同支付商户的配置文件。
 ```

### 四 微信支付备注

1. 服务商模式：https://pay.weixin.qq.com/wiki/doc/apiv3_partner/index.shtml
2. 服务商模式，如JS支付/App支付传递的购买者payer信息命名与普通商户不同，见具体微信支付文档
 ```
	"payer": {
		"sp_openid": "o4GgauInH_RCEdvrrNGrntXDuXXX"
	}
```
3.  接口地址备注

```
下单接口地址
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/jsapi
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/native
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/h5
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/app
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/native
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/h5
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/app

订单查询接口地址
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/id/{transaction_id}
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/id/{transaction_id}

关闭订单接口地址
 (服务商模式)https://api.mch.weixin.qq.com/v3/pay/partner/transactions/out-trade-no/{out_trade_no}/close
 (普通商模式)https://api.mch.weixin.qq.com/v3/pay/transactions/out-trade-no/{out_trade_no}/close
```