### PR TITLE
fix: 服务商模式交易查询

### DIFF
--- a/src/Plugin/Wechat/Pay/Common/QueryPlugin.php
+++ b/src/Plugin/Wechat/Pay/Common/QueryPlugin.php
@@ -51,13 +51,15 @@ class QueryPlugin extends GeneralPlugin
         if (!is_null($payload->get('transaction_id'))) {
             return 'v3/pay/partner/transactions/id/'.
                 $payload->get('transaction_id').
-                '?mchid='.$config->get('mch_id', '');
+                '?sp_mchid='.$config->get('mch_id', '').
+                '&sub_mchid='.$payload->get('sub_mchid', $config->get('sub_mch_id'));
         }
 
         if (!is_null($payload->get('out_trade_no'))) {
             return 'v3/pay/partner/transactions/out-trade-no/'.
                 $payload->get('out_trade_no').
-                '?mchid='.$config->get('mch_id', '');
+                '?sp_mchid='.$config->get('mch_id', '').
+                '&sub_mchid='.$payload->get('sub_mchid', $config->get('sub_mch_id'));
         }
 
         throw new InvalidParamsException(Exception::MISSING_NECESSARY_PARAMS);

--- a/tests/Plugin/Wechat/Pay/Common/QueryPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Common/QueryPluginTest.php
@@ -2,13 +2,10 @@
 
 namespace Yansongda\Pay\Tests\Plugin\Wechat\Pay\Common;
 
-use GuzzleHttp\Psr7\Uri;
-use Psr\Http\Message\RequestInterface;
 use Yansongda\Pay\Plugin\Wechat\Pay\Common\QueryPlugin;
 use Yansongda\Pay\Rocket;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Supports\Collection;
-use Yansongda\Pay\Exception\InvalidParamsException;
 class QueryPluginTest extends TestCase
 {
     public function testNormalTransactionId()
@@ -80,17 +77,4 @@ class QueryPluginTest extends TestCase
         self::assertStringContainsString('sub_mchid=1600314099', $radar->getUri()->getQuery());
         self::assertStringContainsString('sp_mchid=1600314069', $radar->getUri()->getQuery());
     }
-
-//    public function testPartner()
-//    {
-//        $rocket = new Rocket();
-//        $rocket->setParams(['_config' => 'service_provider'])->setPayload(new Collection(['sub_mchid' => '1600314071']));
-//
-//        $plugin = new RefundPlugin();
-//
-//        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
-//        $payload = $result->getPayload();
-//
-//        self::assertEquals('1600314071', $payload->get('sub_mchid'));
-//    }
 }

--- a/tests/Plugin/Wechat/Pay/Common/QueryPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Common/QueryPluginTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Yansongda\Pay\Tests\Plugin\Wechat\Pay\Common;
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+use Yansongda\Pay\Plugin\Wechat\Pay\Common\QueryPlugin;
+use Yansongda\Pay\Rocket;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Supports\Collection;
+use Yansongda\Pay\Exception\InvalidParamsException;
+class QueryPluginTest extends TestCase
+{
+    public function testNormalTransactionId()
+    {
+        $rocket = new Rocket();
+        $config = get_wechat_config($rocket->getParams([]));
+
+        $rocket->setPayload(new Collection(['transaction_id'=>'121212']));
+
+        $plugin = new QueryPlugin();
+
+        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+        $radar = $result->getRadar();
+
+        self::assertEquals('1600314069', $config->get('mch_id'));
+        self::assertEquals('/v3/pay/transactions/id/121212', $radar->getUri()->getPath());
+        self::assertEquals('mchid=1600314069', $radar->getUri()->getQuery());
+        self::assertEquals('GET', $radar->getMethod());
+        self::assertStringNotContainsString('sp_mchid', $radar->getUri()->getQuery());
+    }
+
+    public function testNormalOutTradeNo()
+    {
+        $rocket = new Rocket();
+
+        $rocket->setPayload(new Collection(['out_trade_no'=>'121212']));
+
+        $plugin = new QueryPlugin();
+
+        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+        $radar = $result->getRadar();
+
+        self::assertEquals('/v3/pay/transactions/out-trade-no/121212', $radar->getUri()->getPath());
+        self::assertEquals('mchid=1600314069', $radar->getUri()->getQuery());
+        self::assertEquals('GET', $radar->getMethod());
+        self::assertStringNotContainsString('sp_mchid', $radar->getUri()->getQuery());
+    }
+
+    public function testPartnerTransactionId()
+    {
+        $rocket = new Rocket();
+        $rocket->setParams(['_config' => 'service_provider']);
+        $rocket->setPayload(new Collection(['transaction_id'=>'121212','sub_mchid' => '1600314077']));
+
+        $plugin = new QueryPlugin();
+
+        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+        $radar = $result->getRadar();
+
+        self::assertEquals('/v3/pay/partner/transactions/id/121212', $radar->getUri()->getPath());
+        self::assertEquals('GET', $radar->getMethod());
+        self::assertStringContainsString('sub_mchid=1600314077', $radar->getUri()->getQuery());
+        self::assertStringContainsString('sp_mchid=1600314069', $radar->getUri()->getQuery());
+    }
+
+    public function testPartnerOutTradeNo()
+    {
+        $rocket = new Rocket();
+        $rocket->setParams(['_config' => 'service_provider']);
+        $rocket->setPayload(new Collection(['out_trade_no'=>'121218','sub_mchid' => '1600314099']));
+
+        $plugin = new QueryPlugin();
+
+        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+        $radar = $result->getRadar();
+
+        self::assertEquals('/v3/pay/partner/transactions/out-trade-no/121218', $radar->getUri()->getPath());
+        self::assertEquals('GET', $radar->getMethod());
+        self::assertStringContainsString('sub_mchid=1600314099', $radar->getUri()->getQuery());
+        self::assertStringContainsString('sp_mchid=1600314069', $radar->getUri()->getQuery());
+    }
+
+//    public function testPartner()
+//    {
+//        $rocket = new Rocket();
+//        $rocket->setParams(['_config' => 'service_provider'])->setPayload(new Collection(['sub_mchid' => '1600314071']));
+//
+//        $plugin = new RefundPlugin();
+//
+//        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+//        $payload = $result->getPayload();
+//
+//        self::assertEquals('1600314071', $payload->get('sub_mchid'));
+//    }
+}


### PR DESCRIPTION
#### 辛苦再次检查合并
1. fix 服务商模式交易查询参数。
2. 已测试：JS/Native/小程序/H5的服务商模式收款，查询，退款等核心场景。
3. 暂时业务上没有App，只是模拟debug，目前也是正常。
