### PR TITLE
chore: 优化服务商模式小程序下单场景

### DIFF
--- a/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Plugin\Wechat\Pay\Mini;
 
+use Yansongda\Pay\Pay;
 use Yansongda\Pay\Rocket;
 
 class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokePrepayPlugin
@@ -16,6 +17,10 @@ class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokeP
     protected function getAppid(Rocket $rocket): string
     {
         $config = get_wechat_config($rocket->getParams());
+
+        if (Pay::MODE_SERVICE == $config->get('mode')) {
+            return $rocket->getPayload()->get('sub_appid') ?? $config->get('mini_app_id');
+        }
 
         return $config->get('mini_app_id', '');
     }

--- a/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
@@ -19,7 +19,7 @@ class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokeP
         $config = get_wechat_config($rocket->getParams());
 
         if (Pay::MODE_SERVICE == $config->get('mode')) {
-            return $rocket->getPayload()->get('sub_appid') ?? $config->get('mini_app_id');
+            return $rocket->getPayload()->get('sub_appid', $config->get('mini_app_id', ''));
         }
 
         return $config->get('mini_app_id', '');

--- a/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
@@ -14,7 +14,7 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
     {
         if (Pay::MODE_SERVICE == $config->get('mode')) {
             return [
-                'sp_appid' => $config->get('app_id', ''),
+                'sp_appid' => $config->get('mini_app_id', '') ?: $config->get('mp_app_id', ''),
                 'sp_mchid' => $config->get('mch_id', ''),
                 'sub_appid' => $payload->get('sub_appid', $config->get('sub_mini_app_id')),
                 'sub_mchid' => $payload->get('sub_mchid', $config->get('sub_mch_id')),

--- a/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/PrepayPlugin.php
@@ -14,7 +14,7 @@ class PrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\PrepayPlugin
     {
         if (Pay::MODE_SERVICE == $config->get('mode')) {
             return [
-                'sp_appid' => $config->get('mini_app_id', '') ?: $config->get('mp_app_id', ''),
+                'sp_appid' => $config->get('mini_app_id', $config->get('mp_app_id', '')),
                 'sp_mchid' => $config->get('mch_id', ''),
                 'sub_appid' => $payload->get('sub_appid', $config->get('sub_mini_app_id')),
                 'sub_mchid' => $payload->get('sub_mchid', $config->get('sub_mch_id')),

--- a/tests/Plugin/Wechat/Pay/Mini/InvokePrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Mini/InvokePrepayPluginTest.php
@@ -11,21 +11,41 @@ class InvokePrepayPluginTest extends TestCase
 {
     public function testNormal()
     {
-        $rocket = (new Rocket())->setDestination(new Collection(['prepay_id' => 'yansongda anthony']));
+        $rocket = (new Rocket())->setParams([])->setDestination(new Collection(['prepay_id' => 'yansongda anthony']));
 
         $result = (new InvokePrepayPlugin())->assembly($rocket, function ($rocket) { return $rocket; });
 
         $contents = $result->getDestination();
+        $config = get_wechat_config($rocket->getParams());
 
         self::assertArrayHasKey('appId', $contents->all());
-        self::assertEquals('wx55955316af4ef14', $contents->get('appId'));
+        self::assertEquals($config->get('mini_app_id'), $contents->get('appId'));
         self::assertArrayHasKey('nonceStr', $contents->all());
         self::assertArrayHasKey('package', $contents->all());
         self::assertArrayHasKey('signType', $contents->all());
         self::assertArrayHasKey('paySign', $contents->all());
     }
 
-    public function testPartner()
+    public function testPartnerSpAppId()
+    {
+        $rocket = (new Rocket())->setParams(['_config' => 'service_provider']);
+        $rocket->setPayload(new Collection(['out_trade_no'=>'121218']));
+        $rocket->setDestination(new Collection(['prepay_id' => 'yansongda anthony']));
+
+        $result = (new InvokePrepayPlugin())->assembly($rocket, function ($rocket) { return $rocket; });
+
+        $contents = $result->getDestination();
+        $config = get_wechat_config($rocket->getParams());
+
+        self::assertArrayHasKey('appId', $contents->all());
+        self::assertEquals($config->get('mini_app_id'), $contents->get('appId'));
+        self::assertArrayHasKey('nonceStr', $contents->all());
+        self::assertArrayHasKey('package', $contents->all());
+        self::assertArrayHasKey('signType', $contents->all());
+        self::assertArrayHasKey('paySign', $contents->all());
+    }
+
+    public function testPartnerSubAppId()
     {
         $rocket = (new Rocket())->setParams(['_config' => 'service_provider']);
         $rocket->setPayload(new Collection(['out_trade_no'=>'121218','sub_appid' =>'wx55955316af4ef88']));

--- a/tests/Plugin/Wechat/Pay/Mini/InvokePrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Mini/InvokePrepayPluginTest.php
@@ -24,4 +24,22 @@ class InvokePrepayPluginTest extends TestCase
         self::assertArrayHasKey('signType', $contents->all());
         self::assertArrayHasKey('paySign', $contents->all());
     }
+
+    public function testPartner()
+    {
+        $rocket = (new Rocket())->setParams(['_config' => 'service_provider']);
+        $rocket->setPayload(new Collection(['out_trade_no'=>'121218','sub_appid' =>'wx55955316af4ef88']));
+        $rocket->setDestination(new Collection(['prepay_id' => 'yansongda anthony']));
+
+        $result = (new InvokePrepayPlugin())->assembly($rocket, function ($rocket) { return $rocket; });
+
+        $contents = $result->getDestination();
+
+        self::assertArrayHasKey('appId', $contents->all());
+        self::assertEquals('wx55955316af4ef88', $contents->get('appId'));
+        self::assertArrayHasKey('nonceStr', $contents->all());
+        self::assertArrayHasKey('package', $contents->all());
+        self::assertArrayHasKey('signType', $contents->all());
+        self::assertArrayHasKey('paySign', $contents->all());
+    }
 }

--- a/tests/Plugin/Wechat/Pay/Mini/PrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Mini/PrepayPluginTest.php
@@ -53,4 +53,21 @@ class PrepayPluginTest extends TestCase
         self::assertEquals('123', $payload->get('sub_appid'));
         self::assertEquals('1600314070', $payload->get('sub_mchid'));
     }
+
+    public function testWechatIdPartnerDirect2()
+    {
+        $rocket = new Rocket();
+        $rocket->setParams(['_config' => 'service_provider2'])->setPayload(new Collection(['sub_appid' => '123']));
+
+        $plugin = new PrepayPlugin();
+
+        $result = $plugin->assembly($rocket, function ($rocket) { return $rocket; });
+
+        $payload = $result->getPayload();
+
+        self::assertEquals('123', $payload->get('sub_appid'));
+        self::assertEquals('wx55955316af4ef18', $payload->get('sp_appid'));
+        self::assertEquals('1600314072', $payload->get('sub_mchid'));
+        self::assertEquals('1600314071', $payload->get('sp_mchid'));
+    }
 }

--- a/tests/Plugin/Wechat/Pay/Mini/PrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Mini/PrepayPluginTest.php
@@ -51,7 +51,9 @@ class PrepayPluginTest extends TestCase
         $payload = $result->getPayload();
 
         self::assertEquals('123', $payload->get('sub_appid'));
+        self::assertEquals('wx55955316af4ef14', $payload->get('sp_appid'));
         self::assertEquals('1600314070', $payload->get('sub_mchid'));
+        self::assertEquals('1600314069', $payload->get('sp_mchid'));
     }
 
     public function testWechatIdPartnerDirect2()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,7 +51,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 'service_provider2' => [
                     'mp_app_id' => 'wx55955316af4ef18',
                     'mch_id' => '1600314071',
-                    'mini_app_id' => '',
                     'mch_secret_key' => '53D67FCB97E68F9998CBD17ED7A8D1E2',
                     'mch_secret_cert' => __DIR__.'/Cert/wechatAppPrivateKey.pem',
                     'mch_public_cert_path' => __DIR__.'/Cert/wechatAppPublicKey.pem',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,6 +47,22 @@ class TestCase extends \PHPUnit\Framework\TestCase
                     'sub_mini_app_id' => 'wx55955316af4ef17',
                     'sub_mch_id' => '1600314070',
                     'mode' => Pay::MODE_SERVICE,
+                ],
+                'service_provider2' => [
+                    'mp_app_id' => 'wx55955316af4ef18',
+                    'mch_id' => '1600314071',
+                    'mini_app_id' => '',
+                    'mch_secret_key' => '53D67FCB97E68F9998CBD17ED7A8D1E2',
+                    'mch_secret_cert' => __DIR__.'/Cert/wechatAppPrivateKey.pem',
+                    'mch_public_cert_path' => __DIR__.'/Cert/wechatAppPublicKey.pem',
+                    'wechat_public_cert_path' => [
+                        '45F59D4DABF31918AFCEC556D5D2C6E376675D57' => __DIR__.'/Cert/wechatPublicKey.crt',
+                    ],
+                    'sub_mp_app_id' => 'wx55955316af4ef19',
+                    'sub_app_id' => 'wx55955316af4ef20',
+                    'sub_mini_app_id' => 'wx55955316af4ef21',
+                    'sub_mch_id' => '1600314072',
+                    'mode' => Pay::MODE_SERVICE,
                 ]
             ]
         ];


### PR DESCRIPTION
#### 本次优化服务商模式小程序支付，考虑3种场景
##### 交易场景1：
- 发生在服务商小程序内，则以服务商小程序app_id-做服务端JS下单，
- 此时JS下单 sub_appid可为空，返回给小程序端的参数配置，使用mini_app_id计算签名。
##### 交易场景2：
- 发生在商户小程序内，服务商已经绑定了自有小程序，即mini_app_id有值，则以mini_app_id+sub_mchid做服务端JS下单，
- 此时JS下单sub_appid需要传参且有值，返回给小程序端的参数配置，使用sub_appid计算签名。
##### 交易场景3：
- 发生在商户小程序内，服务商没小程序，仅绑定公众号，即mp_app_id有值，则以mp_app_id+sub_mchid做服务端JS下单，
- 此时JS下单 sub_appid需要传参且有值，返回给小程序端的参数配置，使用sub_appid计算签名。