### PR TITLE
避免因项目使用 bcscale() 函数导致支付宝提示无效支付宝根证书序列号问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-simplexml":"*",
         "ext-libxml": "*",
         "ext-json": "*",
+        "ext-bcmath": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.1",
         "psr/container": "^1.1 | ^2.0",

--- a/src/Plugin/Alipay/PreparePlugin.php
+++ b/src/Plugin/Alipay/PreparePlugin.php
@@ -177,7 +177,8 @@ class PreparePlugin implements PluginInterface
         for ($i = 1; $i <= $len; ++$i) {
             $dec = bcadd(
                 $dec,
-                bcmul(strval(hexdec($hex[$i - 1])), bcpow('16', strval($len - $i)))
+                bcmul(strval(hexdec($hex[$i - 1])), bcpow('16', strval($len - $i), 0), 0),
+                0
             );
         }
 


### PR DESCRIPTION
问题来源：https://github.com/yansongda/pay/issues/491