### PR TITLE
fix:修复验证sign时请求xml，请求协议问题导致无法请求参数

### DIFF
--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -212,7 +212,7 @@ class Wechat implements GatewayApplicationInterface
 
         //TODO 临时注释，$order 需传入数组，且包含type字段，否则后面无法根据type获取对应的appid
         //$config = call_user_func([new $gateway(), 'find'], $order);
-        $config = call_user_func([new $gateway(), 'find'], ['out_trade_no' => $order,'type' => $type]);
+        $config = call_user_func([new $gateway(), 'find'], ['out_trade_no' => $order, 'type' => $type]);
 
         $this->payload = Support::filterPayload($this->payload, $config['order']);
 

--- a/src/Gateways/Wechat.php
+++ b/src/Gateways/Wechat.php
@@ -210,7 +210,9 @@ class Wechat implements GatewayApplicationInterface
             throw new GatewayException("{$gateway} Done Not Exist Or Done Not Has FIND Method");
         }
 
-        $config = call_user_func([new $gateway(), 'find'], $order);
+        //TODO 临时注释，$order 需传入数组，且包含type字段，否则后面无法根据type获取对应的appid
+        //$config = call_user_func([new $gateway(), 'find'], $order);
+        $config = call_user_func([new $gateway(), 'find'], ['out_trade_no' => $order,'type' => $type]);
 
         $this->payload = Support::filterPayload($this->payload, $config['order']);
 

--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -153,13 +153,22 @@ class Support
     {
         Events::dispatch(new Events\ApiRequesting('Wechat', '', self::$instance->getBaseUri().$endpoint, $data));
 
+        //xmlData需增加headers配置，否则微信方无法接收到参数
+        $options = [
+            'headers' => [
+                "Content-Type" => "application/xml"
+            ]
+        ];
+
+        $certOptions = $cert ? [
+            'cert'    => self::$instance->cert_client,
+            'ssl_key' => self::$instance->cert_key,
+        ] : [];
+
         $result = self::$instance->post(
             $endpoint,
             self::toXml($data),
-            $cert ? [
-                'cert' => self::$instance->cert_client,
-                'ssl_key' => self::$instance->cert_key,
-            ] : []
+            array_merge($options, $certOptions)
         );
         $result = is_array($result) ? $result : self::fromXml($result);
 

--- a/src/Gateways/Wechat/Support.php
+++ b/src/Gateways/Wechat/Support.php
@@ -156,12 +156,12 @@ class Support
         //xmlData需增加headers配置，否则微信方无法接收到参数
         $options = [
             'headers' => [
-                "Content-Type" => "application/xml"
-            ]
+                'Content-Type' => 'application/xml',
+            ],
         ];
 
         $certOptions = $cert ? [
-            'cert'    => self::$instance->cert_client,
+            'cert' => self::$instance->cert_client,
             'ssl_key' => self::$instance->cert_key,
         ] : [];
 


### PR DESCRIPTION
修复验证sign时请求xml，无headers配置协议，导致微信方无法接受传递的data参数而导致报错。