### PR TITLE
fix: 微信服务商模式预下单存在子商户appid时，invoke 时也应该为子商户 appid

### DIFF
--- a/src/Plugin/Wechat/Pay/App/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/App/InvokePrepayPlugin.php
@@ -19,7 +19,7 @@ class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokeP
     protected function getInvokeConfig(Rocket $rocket, string $prepayId): Config
     {
         $config = new Config([
-            'appid' => $this->getAppid($rocket),
+            'appid' => $this->getAppId($rocket),
             'partnerid' => get_wechat_config($rocket->getParams())->get('mch_id'),
             'prepayid' => $prepayId,
             'package' => 'Sign=WXPay',
@@ -47,10 +47,8 @@ class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokeP
         return get_wechat_sign($params, $contents);
     }
 
-    protected function getAppid(Rocket $rocket): string
+    protected function getConfigKey(): string
     {
-        $config = get_wechat_config($rocket->getParams());
-
-        return $config->get('app_id', '');
+        return 'app_id';
     }
 }

--- a/src/Plugin/Wechat/Pay/Common/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Common/InvokePrepayPlugin.php
@@ -9,6 +9,7 @@ use Yansongda\Pay\Contract\PluginInterface;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidResponseException;
 use Yansongda\Pay\Logger;
+use Yansongda\Pay\Pay;
 use Yansongda\Pay\Rocket;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
@@ -69,7 +70,7 @@ class InvokePrepayPlugin implements PluginInterface
     protected function getInvokeConfig(Rocket $rocket, string $prepayId): Config
     {
         $config = new Config([
-            'appId' => $this->getAppid($rocket),
+            'appId' => $this->getAppId($rocket),
             'timeStamp' => time().'',
             'nonceStr' => Str::random(32),
             'package' => 'prepay_id='.$prepayId,
@@ -85,10 +86,20 @@ class InvokePrepayPlugin implements PluginInterface
      * @throws \Yansongda\Pay\Exception\ContainerException
      * @throws \Yansongda\Pay\Exception\ServiceNotFoundException
      */
-    protected function getAppid(Rocket $rocket): string
+    protected function getAppId(Rocket $rocket): string
     {
         $config = get_wechat_config($rocket->getParams());
+        $payload = $rocket->getPayload();
 
-        return $config->get('mp_app_id', '');
+        if (Pay::MODE_SERVICE == $config->get('mode') && $payload->has('sub_appid')) {
+            return $payload->get('sub_appid', '');
+        }
+
+        return $config->get($this->getConfigKey(), '');
+    }
+
+    protected function getConfigKey(): string
+    {
+        return 'mp_app_id';
     }
 }

--- a/src/Plugin/Wechat/Pay/Jsapi/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Jsapi/InvokePrepayPlugin.php
@@ -4,6 +4,23 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Plugin\Wechat\Pay\Jsapi;
 
+use Yansongda\Pay\Rocket;
+use Yansongda\Pay\Pay;
+
 class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokePrepayPlugin
 {
+    /**
+     * @throws \Yansongda\Pay\Exception\ContainerException
+     * @throws \Yansongda\Pay\Exception\ServiceNotFoundException
+     */
+    protected function getAppid(Rocket $rocket): string
+    {
+        $config = get_wechat_config($rocket->getParams());
+
+        if (Pay::MODE_SERVICE == $config->get('mode')) {
+            return $rocket->getPayload()->get('sub_appid', $config->get('sub_mp_app_id', ''));
+        }
+
+        return $config->get('mp_app_id', '');
+    }
 }

--- a/src/Plugin/Wechat/Pay/Jsapi/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Jsapi/InvokePrepayPlugin.php
@@ -4,23 +4,6 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Plugin\Wechat\Pay\Jsapi;
 
-use Yansongda\Pay\Rocket;
-use Yansongda\Pay\Pay;
-
 class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokePrepayPlugin
 {
-    /**
-     * @throws \Yansongda\Pay\Exception\ContainerException
-     * @throws \Yansongda\Pay\Exception\ServiceNotFoundException
-     */
-    protected function getAppid(Rocket $rocket): string
-    {
-        $config = get_wechat_config($rocket->getParams());
-
-        if (Pay::MODE_SERVICE == $config->get('mode')) {
-            return $rocket->getPayload()->get('sub_appid', $config->get('sub_mp_app_id', ''));
-        }
-
-        return $config->get('mp_app_id', '');
-    }
 }

--- a/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
+++ b/src/Plugin/Wechat/Pay/Mini/InvokePrepayPlugin.php
@@ -4,23 +4,10 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Plugin\Wechat\Pay\Mini;
 
-use Yansongda\Pay\Pay;
-use Yansongda\Pay\Rocket;
-
 class InvokePrepayPlugin extends \Yansongda\Pay\Plugin\Wechat\Pay\Common\InvokePrepayPlugin
 {
-    /**
-     * @throws \Yansongda\Pay\Exception\ContainerException
-     * @throws \Yansongda\Pay\Exception\ServiceNotFoundException
-     */
-    protected function getAppid(Rocket $rocket): string
+    protected function getConfigKey(): string
     {
-        $config = get_wechat_config($rocket->getParams());
-
-        if (Pay::MODE_SERVICE == $config->get('mode')) {
-            return $rocket->getPayload()->get('sub_appid', $config->get('mini_app_id', ''));
-        }
-
-        return $config->get('mini_app_id', '');
+        return 'mini_app_id';
     }
 }

--- a/tests/Plugin/Wechat/Pay/App/InvokePrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/App/InvokePrepayPluginTest.php
@@ -36,5 +36,21 @@ class InvokePrepayPluginTest extends TestCase
         self::assertArrayHasKey('sign', $contents->all());
         self::assertArrayHasKey('timestamp', $contents->all());
         self::assertArrayHasKey('noncestr', $contents->all());
+        self::assertEquals('yansongda', $contents->get('appid'));
+    }
+
+    public function testPartner()
+    {
+        $rocket = (new Rocket())
+            ->setParams(['_config' => 'service_provider4'])
+            ->setPayload(new Collection(['sub_appid' => '123']))
+            ->setDestination(new Collection(['prepay_id' => 'yansongda']));
+
+        $result = $this->plugin->assembly($rocket, function ($rocket) { return $rocket; });
+
+        $contents = $result->getDestination();
+
+        self::assertArrayHasKey('appid', $contents->all());
+        self::assertEquals('123', $contents->get('appid'));
     }
 }

--- a/tests/Plugin/Wechat/Pay/Common/InvokePrepayPluginTest.php
+++ b/tests/Plugin/Wechat/Pay/Common/InvokePrepayPluginTest.php
@@ -36,6 +36,7 @@ class InvokePrepayPluginTest extends TestCase
         self::assertArrayHasKey('paySign', $contents->all());
         self::assertArrayHasKey('timeStamp', $contents->all());
         self::assertArrayHasKey('nonceStr', $contents->all());
+        self::assertEquals('wx55955316af4ef13', $contents->get('appId'));
     }
 
     public function testWrongPrepayId()
@@ -46,5 +47,24 @@ class InvokePrepayPluginTest extends TestCase
         self::expectExceptionCode(Exception::RESPONSE_MISSING_NECESSARY_PARAMS);
 
         $this->plugin->assembly($rocket, function ($rocket) { return $rocket; });
+    }
+
+    public function testPartner()
+    {
+        $rocket = (new Rocket())
+            ->setParams(['_config' => 'service_provider4'])
+            ->setPayload(new Collection(['sub_appid' => '123']))
+            ->setDestination(new Collection(['prepay_id' => 'yansongda']));
+
+        $result = $this->plugin->assembly($rocket, function ($rocket) { return $rocket; });
+
+        $contents = $result->getDestination();
+
+        self::assertArrayHasKey('appId', $contents->all());
+        self::assertArrayHasKey('package', $contents->all());
+        self::assertArrayHasKey('paySign', $contents->all());
+        self::assertArrayHasKey('timeStamp', $contents->all());
+        self::assertArrayHasKey('nonceStr', $contents->all());
+        self::assertEquals('123', $contents->get('appId'));
     }
 }


### PR DESCRIPTION
修复 #637  ，公众号服务商模式支付，未正确返回 发起公众号，也就是子商户关联公众号 appid 问题