### PR TITLE
change: cancel 的 API 参数只支持 array，不再支持 string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - change(internal): 支付宝 shortcut 从 plugin 文件夹独立出来(#895)
 - change(internal): DirectionInterface 方法由 `parse` 改为 `guide`(#896)
 - change: 查询API方法由 `find` 改为 `query`，同时参数只支持 array(#897)
+- change: cancel 的 API 参数只支持 array，不再支持 string(#890)
 
 ## v3.5.3
 

--- a/src/Contract/ProviderInterface.php
+++ b/src/Contract/ProviderInterface.php
@@ -23,7 +23,7 @@ interface ProviderInterface
 
     public function query(array $order): array|Collection;
 
-    public function cancel(array|string $order): null|array|Collection;
+    public function cancel(array $order): null|array|Collection;
 
     public function close(array|string $order): null|array|Collection;
 

--- a/src/Provider/Alipay.php
+++ b/src/Provider/Alipay.php
@@ -71,10 +71,8 @@ class Alipay extends AbstractProvider
      * @throws InvalidParamsException
      * @throws ServiceNotFoundException
      */
-    public function cancel(array|string $order): null|array|Collection
+    public function cancel(array $order): null|array|Collection
     {
-        $order = is_array($order) ? $order : ['out_trade_no' => $order];
-
         Event::dispatch(new Event\MethodCalled('alipay', __METHOD__, $order, null));
 
         return $this->__call('cancel', [$order]);

--- a/src/Provider/Unipay.php
+++ b/src/Provider/Unipay.php
@@ -64,12 +64,8 @@ class Unipay extends AbstractProvider
      * @throws InvalidParamsException
      * @throws ServiceNotFoundException
      */
-    public function cancel(array|string $order): null|array|Collection
+    public function cancel(array $order): null|array|Collection
     {
-        if (!is_array($order)) {
-            throw new InvalidParamsException(Exception::UNIPAY_CANCEL_STRING_NOT_SUPPORTED);
-        }
-
         Event::dispatch(new Event\MethodCalled('unipay', __METHOD__, $order, null));
 
         return $this->__call('cancel', [$order]);

--- a/src/Provider/Wechat.php
+++ b/src/Provider/Wechat.php
@@ -74,7 +74,7 @@ class Wechat extends AbstractProvider
     /**
      * @throws InvalidParamsException
      */
-    public function cancel(array|string $order): null|array|Collection
+    public function cancel(array $order): null|array|Collection
     {
         throw new InvalidParamsException(Exception::METHOD_NOT_SUPPORTED, 'Wechat does not support cancel api');
     }

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -136,7 +136,7 @@ class FooProviderStub extends AbstractProvider
         return new Collection();
     }
 
-    public function cancel(array|string $order): Collection
+    public function cancel(array $order): Collection
     {
         return new Collection();
     }

--- a/tests/Provider/UnipayTest.php
+++ b/tests/Provider/UnipayTest.php
@@ -176,10 +176,6 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
         ]);
 
         self::assertArrayHasKey('respMsg', $result->all());
-
-        self::expectException(InvalidParamsException::class);
-        self::expectExceptionCode(Exception::UNIPAY_CANCEL_STRING_NOT_SUPPORTED);
-        Pay::unipay()->cancel('123');
     }
 
     public function testClose()


### PR DESCRIPTION
close: #899 