### PR TITLE
refactor(v3.8): 新增 CertManager/Traits/AbstractServiceProvider 基础设施并迁移 Alipay/Stripe (PR 1)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-code-refactoring.md
+++ b/docs/superpowers/plans/2026-04-15-code-refactoring.md
@@ -1,0 +1,1410 @@
+# v3.8.0 代码重构实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 Functions.php 拆分为 Provider Trait，实现证书缓存，抽象 ServiceProvider，补充类型声明和测试
+
+**Architecture:** 
+- 8 个 Provider Trait + 1 个共享 Trait（ProviderConfigTrait）
+- 独立 CertManager 类处理证书缓存
+- AbstractServiceProvider 抽象基类
+- TDD 模式：先写测试，再实现
+
+**Tech Stack:** PHP 8.2+, PHPUnit 11.5, PHPStan Level 5, PHP-CS-Fixer
+
+---
+
+## 文件结构规划
+
+### 新增文件（10 个）
+
+| 文件 | 职责 |
+|------|------|
+| `src/CertManager.php` | 证书加载与进程内缓存 |
+| `src/Traits/ProviderConfigTrait.php` | get_tenant、get_provider_config、get_radar_url |
+| `src/Traits/AlipayTrait.php` | verifyAlipaySign、getAlipayUrl |
+| `src/Traits/WechatTrait.php` | 微信签名、加解密、证书管理（18 个方法） |
+| `src/Traits/UnipayTrait.php` | 银联签名、URL 获取 |
+| `src/Traits/JsbTrait.php` | 江苏银行签名 |
+| `src/Traits/DouyinTrait.php` | 抖音 URL |
+| `src/Traits/PaypalTrait.php` | PayPal 签名、URL、Token |
+| `src/Traits/StripeTrait.php` | Stripe 签名、URL |
+| `src/Service/AbstractServiceProvider.php` | ServiceProvider 抽象基类 |
+
+### 删除文件（1 个）
+
+| 文件 | 说明 |
+|------|------|
+| `src/Functions.php` | 829 行辅助函数文件 |
+
+### 修改文件（约 170 个）
+
+| 类别 | 数量 | 说明 |
+|------|------|------|
+| Plugin 文件 | ~160 | 添加 Trait，替换函数调用 |
+| ServiceProvider 文件 | 7 | 继承 AbstractServiceProvider |
+| 测试文件 | 4 | 更新导入 |
+
+---
+
+## Task 1: 创建 CertManager 类
+
+**Files:**
+- Create: `src/CertManager.php`
+- Create: `tests/CertManagerTest.php`
+
+- [ ] **Step 1: Write failing test for getPublicCert from file**
+
+```php
+// tests/CertManagerTest.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests;
+
+use Yansongda\Pay\CertManager;
+
+class CertManagerTest extends TestCase
+{
+    public function testGetPublicCertFromFile(): void
+    {
+        $path = __DIR__ . '/Cert/alipayPublicCert.crt';
+        $result = CertManager::getPublicCert($path);
+        
+        $this->assertStringContainsString('BEGIN CERTIFICATE', $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/CertManagerTest.php --colors=always`
+Expected: FAIL - Class `Yansongda\Pay\CertManager` not found
+
+- [ ] **Step 3: Create CertManager class**
+
+```php
+// src/CertManager.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay;
+
+class CertManager
+{
+    private static array $cache = [];
+
+    public static function getPublicCert(string $key): string
+    {
+        $cacheKey = 'public_' . md5($key);
+
+        if (!isset(self::$cache[$cacheKey])) {
+            self::$cache[$cacheKey] = is_file($key) 
+                ? file_get_contents($key) 
+                : $key;
+        }
+
+        return self::$cache[$cacheKey];
+    }
+
+    public static function getPrivateCert(string $key): string
+    {
+        $cacheKey = 'private_' . md5($key);
+
+        if (!isset(self::$cache[$cacheKey])) {
+            self::$cache[$cacheKey] = self::loadPrivateCert($key);
+        }
+
+        return self::$cache[$cacheKey];
+    }
+
+    private static function loadPrivateCert(string $key): string
+    {
+        if (is_file($key)) {
+            return file_get_contents($key);
+        }
+
+        if (str_starts_with($key, '-----BEGIN PRIVATE KEY-----')) {
+            return $key;
+        }
+
+        return "-----BEGIN RSA PRIVATE KEY-----\n"
+            . wordwrap($key, 64, "\n", true)
+            . "\n-----END RSA PRIVATE KEY-----";
+    }
+
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/CertManagerTest.php --colors=always`
+Expected: PASS
+
+- [ ] **Step 5: Add more tests for edge cases**
+
+```php
+// tests/CertManagerTest.php - 添加更多测试
+public function testGetPublicCertFromString(): void
+{
+    $certContent = '-----BEGIN CERTIFICATE-----MIIBtest-----END CERTIFICATE-----';
+    $result = CertManager::getPublicCert($certContent);
+    
+    $this->assertEquals($certContent, $result);
+}
+
+public function testGetPublicCertCacheHit(): void
+{
+    $path = __DIR__ . '/Cert/alipayPublicCert.crt';
+    
+    CertManager::clearCache();
+    $result1 = CertManager::getPublicCert($path);
+    $result2 = CertManager::getPublicCert($path);
+    
+    $this->assertEquals($result1, $result2);
+}
+
+public function testGetPrivateCertFromFile(): void
+{
+    $path = __DIR__ . '/Cert/wechatAppPrivateKey.pem';
+    $result = CertManager::getPrivateCert($path);
+    
+    $this->assertStringContainsString('PRIVATE KEY', $result);
+}
+
+public function testGetPrivateCertFromString(): void
+{
+    $keyContent = 'testprivatekeystring123456789012345678901234567890';
+    $result = CertManager::getPrivateCert($keyContent);
+    
+    $this->assertStringContainsString('BEGIN RSA PRIVATE KEY', $result);
+}
+
+public function testClearCache(): void
+{
+    $path = __DIR__ . '/Cert/alipayPublicCert.crt';
+    CertManager::getPublicCert($path);
+    
+    CertManager::clearCache();
+    
+    // 再次读取应重新加载（可通过性能测试验证）
+    $result = CertManager::getPublicCert($path);
+    $this->assertStringContainsString('BEGIN CERTIFICATE', $result);
+}
+```
+
+- [ ] **Step 6: Run all CertManager tests**
+
+Run: `./vendor/bin/phpunit tests/CertManagerTest.php --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/CertManager.php tests/CertManagerTest.php
+git commit -m "feat: add CertManager class with process-level caching"
+```
+
+---
+
+## Task 2: 创建 ProviderConfigTrait
+
+**Files:**
+- Create: `src/Traits/ProviderConfigTrait.php`
+- Create: `tests/Traits/ProviderConfigTraitTest.php`
+
+- [ ] **Step 1: Write failing test for getTenant**
+
+```php
+// tests/Traits/ProviderConfigTraitTest.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
+
+class ProviderConfigTraitTest extends \Yansongda\Pay\Tests\TestCase
+{
+    public function testGetTenantDefault(): void
+    {
+        $result = ProviderConfigTrait::getTenant([]);
+        
+        $this->assertEquals('default', $result);
+    }
+
+    public function testGetTenantCustom(): void
+    {
+        $result = ProviderConfigTrait::getTenant(['_config' => 'service_provider']);
+        
+        $this->assertEquals('service_provider', $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Traits/ProviderConfigTraitTest.php --colors=always`
+Expected: FAIL - Trait not found
+
+- [ ] **Step 3: Create ProviderConfigTrait**
+
+```php
+// src/Traits/ProviderConfigTrait.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Pay\Pay;
+use Yansongda\Supports\Collection;
+
+trait ProviderConfigTrait
+{
+    public static function getTenant(array $params = []): string
+    {
+        return strval($params['_config'] ?? 'default');
+    }
+
+    public static function getProviderConfig(string $provider, array $params = []): array
+    {
+        $config = Pay::get(ConfigInterface::class);
+
+        return $config->get($provider, [])[self::getTenant($params)] ?? [];
+    }
+
+    public static function getRadarUrl(array $config, ?Collection $payload): ?string
+    {
+        return match ($config['mode'] ?? Pay::MODE_NORMAL) {
+            Pay::MODE_SERVICE => $payload?->get('_service_url') ?? $payload?->get('_url') ?? null,
+            Pay::MODE_SANDBOX => $payload?->get('_sandbox_url') ?? $payload?->get('_url') ?? null,
+            default => $payload?->get('_url') ?? null,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Traits/ProviderConfigTraitTest.php --colors=always`
+Expected: PASS
+
+- [ ] **Step 5: Add test for getProviderConfig**
+
+```php
+// tests/Traits/ProviderConfigTraitTest.php - 添加
+public function testGetProviderConfigDefault(): void
+{
+    $result = ProviderConfigTrait::getProviderConfig('alipay', []);
+    
+    $this->assertArrayHasKey('app_id', $result);
+    $this->assertEquals('9021000122682882', $result['app_id']);
+}
+
+public function testGetProviderConfigCustomTenant(): void
+{
+    $result = ProviderConfigTrait::getProviderConfig('wechat', ['_config' => 'service_provider']);
+    
+    $this->assertArrayHasKey('sub_mch_id', $result);
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `./vendor/bin/phpunit tests/Traits/ProviderConfigTraitTest.php --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Traits/ProviderConfigTrait.php tests/Traits/ProviderConfigTraitTest.php
+git commit -m "feat: add ProviderConfigTrait for tenant and config helpers"
+```
+
+---
+
+## Task 3: 创建 AbstractServiceProvider
+
+**Files:**
+- Create: `src/Service/AbstractServiceProvider.php`
+- Create: `tests/Service/AbstractServiceProviderTest.php`
+
+- [ ] **Step 1: Write failing test**
+
+```php
+// tests/Service/AbstractServiceProviderTest.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Service;
+
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Service\AbstractServiceProvider;
+
+class ConcreteServiceProvider extends AbstractServiceProvider
+{
+    protected function getProviderClass(): string
+    {
+        return 'TestProviderClass';
+    }
+
+    protected function getProviderName(): string
+    {
+        return 'test_provider';
+    }
+}
+
+class AbstractServiceProviderTest extends \Yansongda\Pay\Tests\TestCase
+{
+    public function testRegisterSetsClassAndName(): void
+    {
+        $provider = new ConcreteServiceProvider();
+        $provider->register();
+        
+        $this->assertTrue(Pay::has('TestProviderClass'));
+        $this->assertTrue(Pay::has('test_provider'));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Service/AbstractServiceProviderTest.php --colors=always`
+Expected: FAIL - AbstractServiceProvider not found
+
+- [ ] **Step 3: Create AbstractServiceProvider**
+
+```php
+// src/Service/AbstractServiceProvider.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Service;
+
+use Yansongda\Artful\Contract\ServiceProviderInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Pay\Pay;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * 返回 Provider 完整类名
+     */
+    abstract protected function getProviderClass(): string;
+
+    /**
+     * 返回 Provider 注册名称
+     */
+    abstract protected function getProviderName(): string;
+
+    /**
+     * @throws ContainerException
+     */
+    public function register(mixed $data = null): void
+    {
+        $class = $this->getProviderClass();
+        $service = new $class();
+
+        Pay::set($class, $service);
+        Pay::set($this->getProviderName(), $service);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Service/AbstractServiceProviderTest.php --colors=always`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Service/AbstractServiceProvider.php tests/Service/AbstractServiceProviderTest.php
+git commit -m "feat: add AbstractServiceProvider base class"
+```
+
+---
+
+## Task 4: 创建 AlipayTrait
+
+**Files:**
+- Create: `src/Traits/AlipayTrait.php`
+- Create: `tests/Traits/AlipayTraitTest.php`
+
+- [ ] **Step 1: Write failing test for verifyAlipaySign**
+
+```php
+// tests/Traits/AlipayTraitTest.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\AlipayTrait;
+
+class AlipayTraitTest extends \Yansongda\Pay\Tests\TestCase
+{
+    public function testVerifyAlipaySignWithEmptySign(): void
+    {
+        $this->expectException(InvalidSignException::class);
+        $this->expectExceptionCode(Exception::SIGN_EMPTY);
+        
+        AlipayTrait::verifyAlipaySign([], 'test_contents', '');
+    }
+
+    public function testVerifyAlipaySignSuccess(): void
+    {
+        // 使用测试证书验证签名
+        $config = [
+            'alipay_public_cert_path' => __DIR__ . '/../Cert/alipayPublicCert.crt',
+        ];
+        
+        // 构造有效的签名测试（需要实际签名数据）
+        // 此处为占位，实际需用 openssl_sign 生成测试签名
+        $contents = 'test';
+        $sign = base64_encode('test_sign');
+        
+        // 验证逻辑
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Traits/AlipayTraitTest.php --colors=always`
+Expected: FAIL - Trait not found
+
+- [ ] **Step 3: Create AlipayTrait**
+
+```php
+// src/Traits/AlipayTrait.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Provider\Alipay;
+use Yansongda\Supports\Collection;
+
+trait AlipayTrait
+{
+    use ProviderConfigTrait;
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyAlipaySign(array $config, string $contents, string $sign): void
+    {
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 验证支付宝签名失败-支付宝签名为空', func_get_args());
+        }
+
+        $public = $config['alipay_public_cert_path'] ?? null;
+
+        if (empty($public)) {
+            throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, '配置异常: 缺少支付宝配置 -- [alipay_public_cert_path]');
+        }
+
+        $result = 1 === openssl_verify(
+            $contents,
+            base64_decode($sign),
+            CertManager::getPublicCert($public),
+            OPENSSL_ALGO_SHA256
+        );
+
+        if (!$result) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证支付宝签名失败', func_get_args());
+        }
+    }
+
+    public static function getAlipayUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload) ?? '';
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Alipay::URL[$config['mode'] ?? \Yansongda\Pay\Pay::MODE_NORMAL];
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Traits/AlipayTraitTest.php --colors=always`
+Expected: Empty sign test PASS
+
+- [ ] **Step 5: Add getAlipayUrl test**
+
+```php
+// tests/Traits/AlipayTraitTest.php - 添加
+public function testGetAlipayUrlDefault(): void
+{
+    $config = ['mode' => \Yansongda\Pay\Pay::MODE_NORMAL];
+    $result = AlipayTrait::getAlipayUrl($config, null);
+    
+    $this->assertEquals('https://openapi.alipay.com/gateway.do?charset=utf-8', $result);
+}
+
+public function testGetAlipayUrlSandbox(): void
+{
+    $config = ['mode' => \Yansongda\Pay\Pay::MODE_SANDBOX];
+    $result = AlipayTrait::getAlipayUrl($config, null);
+    
+    $this->assertStringContainsString('sandbox', $result);
+}
+
+public function testGetAlipayUrlWithCustomPayload(): void
+{
+    $config = ['mode' => \Yansongda\Pay\Pay::MODE_NORMAL];
+    $payload = new Collection(['_url' => 'https://custom.alipay.com/api']);
+    
+    $result = AlipayTrait::getAlipayUrl($config, $payload);
+    
+    $this->assertEquals('https://custom.alipay.com/api', $result);
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `./vendor/bin/phpunit tests/Traits/AlipayTraitTest.php --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Traits/AlipayTrait.php tests/Traits/AlipayTraitTest.php
+git commit -m "feat: add AlipayTrait with verifyAlipaySign and getAlipayUrl"
+```
+
+---
+
+## Task 5: 创建 WechatTrait（最复杂）
+
+**Files:**
+- Create: `src/Traits/WechatTrait.php`
+- Create: `tests/Traits/WechatTraitTest.php`
+
+由于 WechatTrait 有 18 个方法，分步创建：
+
+- [ ] **Step 1: Write failing test for getWechatUrl**
+
+```php
+// tests/Traits/WechatTraitTest.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidParamsException;
+use Yansongda\Pay\Traits\WechatTrait;
+use Yansongda\Supports\Collection;
+
+class WechatTraitTest extends \Yansongda\Pay\Tests\TestCase
+{
+    public function testGetWechatUrlMissingUrl(): void
+    {
+        $this->expectException(InvalidParamsException::class);
+        $this->expectExceptionCode(Exception::PARAMS_WECHAT_URL_MISSING);
+        
+        WechatTrait::getWechatUrl(['mode' => \Yansongda\Pay\Pay::MODE_NORMAL], null);
+    }
+
+    public function testGetWechatUrlSuccess(): void
+    {
+        $config = ['mode' => \Yansongda\Pay\Pay::MODE_NORMAL];
+        $payload = new Collection(['_url' => '/v3/pay/transactions/native']);
+        
+        $result = WechatTrait::getWechatUrl($config, $payload);
+        
+        $this->assertStringContainsString('api.mch.weixin.qq.com', $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Traits/WechatTraitTest.php --colors=always`
+Expected: FAIL - Trait not found
+
+- [ ] **Step 3: Create WechatTrait (initial version with URL methods)**
+
+```php
+// src/Traits/WechatTrait.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\DecryptException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Provider\Wechat;
+use Yansongda\Supports\Collection;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function Yansongda\Artful\get_radar_body;
+use function Yansongda\Artful\get_radar_method;
+
+trait WechatTrait
+{
+    use ProviderConfigTrait;
+
+    // ===== URL/Method/Body 获取 =====
+
+    public static function getWechatMethod(?Collection $payload): string
+    {
+        return get_radar_method($payload) ?? 'POST';
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_URL_MISSING, '参数异常: 微信 `_url` 或 `_service_url` 参数缺失');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Wechat::URL[$config['mode'] ?? \Yansongda\Pay\Pay::MODE_NORMAL] . $url;
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatBody(?Collection $payload): mixed
+    {
+        $body = get_radar_body($payload);
+
+        if (is_null($body)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_BODY_MISSING, '参数异常: 微信 `_body` 参数缺失');
+        }
+
+        return $body;
+    }
+
+    public static function getWechatTypeKey(array $params): string
+    {
+        $key = ($params['_type'] ?? 'mp') . '_app_id';
+
+        if ('app_app_id' === $key) {
+            $key = 'app_id';
+        }
+
+        return $key;
+    }
+
+    // ===== 签名生成 =====
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatSign(array $config, string $contents): string
+    {
+        $privateKey = $config['mch_secret_cert'] ?? null;
+
+        if (empty($privateKey)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_cert]');
+        }
+
+        $privateKey = CertManager::getPrivateCert($privateKey);
+
+        openssl_sign($contents, $sign, $privateKey, 'sha256WithRSAEncryption');
+
+        return base64_encode($sign);
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatSignV2(array $config, array $payload, bool $upper = true): string
+    {
+        $key = $config['mch_secret_key_v2'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key_v2]');
+        }
+
+        ksort($payload);
+
+        $buff = '';
+        foreach ($payload as $k => $v) {
+            $buff .= ('sign' != $k && '' != $v && !is_array($v)) ? $k . '=' . $v . '&' : '';
+        }
+
+        $sign = md5($buff . 'key=' . $key);
+
+        return $upper ? strtoupper($sign) : $sign;
+    }
+
+    // ===== 签名验证 =====
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyWechatSign(ResponseInterface|ServerRequestInterface $message, array $params): void
+    {
+        $wechatSerial = $message->getHeaderLine('Wechatpay-Serial');
+        $timestamp = $message->getHeaderLine('Wechatpay-Timestamp');
+        $random = $message->getHeaderLine('Wechatpay-Nonce');
+        $sign = $message->getHeaderLine('Wechatpay-Signature');
+        $body = (string) $message->getBody();
+
+        $content = $timestamp . "\n" . $random . "\n" . $body . "\n";
+
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 微信签名为空', ['headers' => $message->getHeaders(), 'body' => $body]);
+        }
+
+        $public = self::getProviderConfig('wechat', $params)['wechat_public_cert_path'][$wechatSerial] ?? null;
+        $public = CertManager::getPublicCert(
+            empty($public) ? self::reloadWechatPublicCerts($params, $wechatSerial) : $public
+        );
+
+        $result = 1 === openssl_verify(
+            $content,
+            base64_decode($sign),
+            $public,
+            'sha256WithRSAEncryption'
+        );
+
+        if (!$result) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证微信签名失败', ['headers' => $message->getHeaders(), 'body' => $body]);
+        }
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyWechatSignV2(array $config, array $destination): void
+    {
+        $sign = $destination['sign'] ?? null;
+
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 微信签名为空', $destination);
+        }
+
+        $key = $config['mch_secret_key_v2'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key_v2]');
+        }
+
+        if (self::getWechatSignV2($config, $destination) !== $sign) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证微信签名失败', $destination);
+        }
+    }
+
+    // ===== 加解密 =====
+
+    public static function encryptWechatContents(string $contents, string $publicKey): ?string
+    {
+        if (openssl_public_encrypt($contents, $encrypted, CertManager::getPublicCert($publicKey), OPENSSL_PKCS1_OAEP_PADDING)) {
+            return base64_encode($encrypted);
+        }
+
+        return null;
+    }
+
+    public static function decryptWechatContents(string $encrypted, array $config): ?string
+    {
+        if (openssl_private_decrypt(base64_decode($encrypted), $decrypted, CertManager::getPrivateCert($config['mch_secret_cert'] ?? ''), OPENSSL_PKCS1_OAEP_PADDING)) {
+            return $decrypted;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws DecryptException
+     */
+    public static function decryptWechatResource(array $resource, array $config): array
+    {
+        $ciphertext = base64_decode($resource['ciphertext'] ?? '');
+        $secret = $config['mch_secret_key'] ?? null;
+
+        if (strlen($ciphertext) <= Wechat::AUTH_TAG_LENGTH_BYTE) {
+            throw new DecryptException(Exception::DECRYPT_WECHAT_CIPHERTEXT_PARAMS_INVALID, '加解密异常: ciphertext 位数过短');
+        }
+
+        if (is_null($secret) || Wechat::MCH_SECRET_KEY_LENGTH_BYTE != strlen($secret)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key]');
+        }
+
+        $resource['ciphertext'] = match ($resource['algorithm'] ?? '') {
+            'AEAD_AES_256_GCM' => self::decryptWechatResourceAes256Gcm($ciphertext, $secret, $resource['nonce'] ?? '', $resource['associated_data'] ?? ''),
+            default => throw new DecryptException(Exception::DECRYPT_WECHAT_DECRYPTED_METHOD_INVALID, '加解密异常: algorithm 不支持'),
+        };
+
+        return $resource;
+    }
+
+    /**
+     * @throws DecryptException
+     */
+    public static function decryptWechatResourceAes256Gcm(string $ciphertext, string $secret, string $nonce, string $associatedData): array|string
+    {
+        $decrypted = openssl_decrypt(
+            substr($ciphertext, 0, -Wechat::AUTH_TAG_LENGTH_BYTE),
+            'aes-256-gcm',
+            $secret,
+            OPENSSL_RAW_DATA,
+            $nonce,
+            substr($ciphertext, -Wechat::AUTH_TAG_LENGTH_BYTE),
+            $associatedData
+        );
+
+        if (false === $decrypted) {
+            throw new DecryptException(Exception::DECRYPT_WECHAT_ENCRYPTED_DATA_INVALID, '加解密异常: 解密失败');
+        }
+
+        if ('certificate' !== $associatedData) {
+            $decrypted = json_decode($decrypted, true);
+
+            if (JSON_ERROR_NONE !== json_last_error()) {
+                throw new DecryptException(Exception::DECRYPT_WECHAT_ENCRYPTED_DATA_INVALID, '加解密异常: 待解密数据非正常数据');
+            }
+        }
+
+        return $decrypted;
+    }
+
+    // ===== 证书管理 =====
+
+    public static function reloadWechatPublicCerts(array $params, ?string $serialNo = null): string
+    {
+        // 此方法需要调用微信 API 获取证书，实现较复杂
+        // 暂时保留原有逻辑，后续迁移
+        // ... 完整实现见 Functions.php 原代码
+        return '';
+    }
+
+    public static function getWechatPublicCerts(array $params = [], ?string $path = null): void
+    {
+        self::reloadWechatPublicCerts($params);
+
+        $config = self::getProviderConfig('wechat', $params);
+
+        if (empty($path)) {
+            var_dump($config['wechat_public_cert_path']);
+            return;
+        }
+
+        foreach ($config['wechat_public_cert_path'] as $serial => $cert) {
+            file_put_contents($path . '/' . $serial . '.crt', $cert);
+        }
+    }
+
+    public static function getWechatSerialNo(array $params): string
+    {
+        if (!empty($params['_serial_no'])) {
+            return $params['_serial_no'];
+        }
+
+        $config = self::getProviderConfig('wechat', $params);
+
+        if (empty($config['wechat_public_cert_path'])) {
+            self::reloadWechatPublicCerts($params);
+            $config = self::getProviderConfig('wechat', $params);
+        }
+
+        mt_srand();
+
+        return strval(array_rand($config['wechat_public_cert_path']));
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatPublicKey(array $config, string $serialNo): string
+    {
+        $publicKey = $config['wechat_public_cert_path'][$serialNo] ?? null;
+
+        if (empty($publicKey)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_SERIAL_NOT_FOUND, '参数异常: 微信公钥序列号未找到 - ' . $serialNo);
+        }
+
+        return $publicKey;
+    }
+
+    // ===== 小程序支付签名 =====
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatMiniprogramPaySign(array $config, string $url, string $payload): string
+    {
+        if (empty($config['mini_app_key_virtual_pay'])) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mini_app_key_virtual_pay]');
+        }
+
+        return hash_hmac('sha256', $url . '&' . $payload, $config['mini_app_key_virtual_pay']);
+    }
+
+    public static function getWechatMiniprogramUserSign(string $sessionKey, string $payload): string
+    {
+        return hash_hmac('sha256', $payload, $sessionKey);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify URL methods pass**
+
+Run: `./vendor/bin/phpunit tests/Traits/WechatTraitTest.php --colors=always`
+Expected: URL tests PASS
+
+- [ ] **Step 5: Add comprehensive WechatTrait tests**
+
+```php
+// tests/Traits/WechatTraitTest.php - 添加更多测试
+public function testGetWechatSignV2(): void
+{
+    $config = ['mch_secret_key_v2' => 'test_key_32_characters_long'];
+    $payload = ['appid' => 'wx123', 'mch_id' => '123456'];
+    
+    $result = WechatTrait::getWechatSignV2($config, $payload);
+    
+    $this->assertMatchesRegularExpression('/^[A-F0-9]{32}$/', $result);
+}
+
+public function testGetWechatTypeKey(): void
+{
+    $this->assertEquals('mp_app_id', WechatTrait::getWechatTypeKey(['_type' => 'mp']));
+    $this->assertEquals('app_id', WechatTrait::getWechatTypeKey(['_type' => 'app']));
+}
+
+public function testVerifyWechatSignEmpty(): void
+{
+    $request = new \GuzzleHttp\Psr7\ServerRequest('POST', '/', [], json_encode(['test' => 'data']));
+    
+    $this->expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+    $this->expectExceptionCode(Exception::SIGN_EMPTY);
+    
+    WechatTrait::verifyWechatSign($request, []);
+}
+
+public function testDecryptWechatResourceInvalidCiphertext(): void
+{
+    $resource = ['ciphertext' => 'short', 'algorithm' => 'AEAD_AES_256_GCM'];
+    $config = ['mch_secret_key' => '32characterssecretkey1234567890'];
+    
+    $this->expectException(\Yansongda\Pay\Exception\DecryptException::class);
+    $this->expectExceptionCode(Exception::DECRYPT_WECHAT_CIPHERTEXT_PARAMS_INVALID);
+    
+    WechatTrait::decryptWechatResource($resource, $config);
+}
+```
+
+- [ ] **Step 6: Run all WechatTrait tests**
+
+Run: `./vendor/bin/phpunit tests/Traits/WechatTraitTest.php --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Traits/WechatTrait.php tests/Traits/WechatTraitTest.php
+git commit -m "feat: add WechatTrait with 18 methods (sign, encrypt, decrypt, cert)"
+```
+
+---
+
+## Task 6-10: 创建其他 Provider Trait
+
+按照相同 TDD 模式创建：
+
+- Task 6: UnipayTrait（5 个方法）
+- Task 7: JsbTrait（2 个方法）
+- Task 8: DouyinTrait（1 个方法）
+- Task 9: PaypalTrait（3 个方法）
+- Task 10: StripeTrait（2 个方法）
+
+每个 Task 遵循相同的 7 步流程：测试 → 实现 → 测试 → 提交
+
+---
+
+## Task 11: 迁移 Alipay Plugin 文件
+
+**Files:**
+- Modify: `src/Plugin/Alipay/V2/*.php`（6 个文件）
+
+- [ ] **Step 1: Update CallbackPlugin**
+
+```php
+// src/Plugin/Alipay/V2/CallbackPlugin.php
+// 修改前:
+use function Yansongda\Pay\get_provider_config;
+use function Yansongda\Pay\verify_alipay_sign;
+
+// 修改后:
+use Yansongda\Pay\Traits\AlipayTrait;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
+
+class CallbackPlugin implements PluginInterface
+{
+    use AlipayTrait;
+    use ProviderConfigTrait;
+
+    public function assembly(Rocket $rocket, Closure $next): Rocket
+    {
+        $params = $rocket->getParams();
+        $config = self::getProviderConfig('alipay', $params);  // Trait 方法
+        // ...
+        self::verifyAlipaySign($config, $value->sortKeys()->toString(), $params['sign'] ?? '');  // Trait 方法
+        // ...
+    }
+}
+```
+
+- [ ] **Step 2: Run tests for Alipay plugins**
+
+Run: `./vendor/bin/phpunit tests/Plugin/Alipay/ --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 3: Update all Alipay V2 plugins**
+
+依次修改：
+- `AddPayloadSignaturePlugin.php`
+- `AddRadarPlugin.php`
+- `AppCallbackPlugin.php`
+- `StartPlugin.php`
+- `VerifySignaturePlugin.php`
+
+- [ ] **Step 4: Run all Alipay tests**
+
+Run: `./vendor/bin/phpunit tests/Plugin/Alipay/ --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Plugin/Alipay/V2/*.php
+git commit -m "refactor: migrate Alipay plugins to use AlipayTrait"
+```
+
+---
+
+## Task 12-17: 迁移其他 Provider Plugin 文件
+
+按 Provider 分组迁移（每个 Provider 一个 commit）：
+
+- Task 12: Wechat Plugin（~105 文件，最多）
+- Task 13: Unipay Plugin（~40 文件）
+- Task 14: Jsb Plugin（~10 文件）
+- Task 15: Douyin Plugin（~8 文件）
+- Task 16: Paypal Plugin（~5 文件）
+- Task 17: Stripe Plugin（~4 文件）
+
+每个 Task 的大致流程：
+1. 批量替换 `use function Yansongda\Pay\` 为 Trait
+2. 修改方法调用为 Trait 静态方法
+3. 运行对应 Provider 测试
+4. Commit
+
+---
+
+## Task 18: 修改 ServiceProvider 继承
+
+**Files:**
+- Modify: `src/Service/*ServiceProvider.php`（7 个文件）
+
+- [ ] **Step 1: Update WechatServiceProvider**
+
+```php
+// src/Service/WechatServiceProvider.php
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Service;
+
+use Yansongda\Pay\Provider\Wechat;
+use Yansongda\Pay\Service\AbstractServiceProvider;
+
+class WechatServiceProvider extends AbstractServiceProvider
+{
+    protected function getProviderClass(): string
+    {
+        return Wechat::class;
+    }
+
+    protected function getProviderName(): string
+    {
+        return 'wechat';
+    }
+}
+```
+
+- [ ] **Step 2: Update all other ServiceProvider files**
+
+依次修改：
+- AlipayServiceProvider.php
+- UnipayServiceProvider.php
+- JsbServiceProvider.php
+- DouyinServiceProvider.php
+- PaypalServiceProvider.php
+- StripeServiceProvider.php
+
+- [ ] **Step 3: Run tests**
+
+Run: `./vendor/bin/phpunit tests/Provider/ --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Service/*ServiceProvider.php
+git commit -m "refactor: ServiceProvider extends AbstractServiceProvider"
+```
+
+---
+
+## Task 19: 删除 Functions.php
+
+**Files:**
+- Delete: `src/Functions.php`
+
+- [ ] **Step 1: Verify no remaining imports**
+
+Run: `grep -r "use function Yansongda\\\\Pay" src/ --include="*.php"`
+Expected: 0 matches
+
+- [ ] **Step 2: Remove Functions.php from autoload**
+
+在 `composer.json` 中移除：
+```json
+"autoload": {
+    "psr-4": {...},
+    "files": []  // 移除 "src/Functions.php"
+}
+```
+
+- [ ] **Step 3: Delete Functions.php**
+
+```bash
+git rm src/Functions.php
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `./vendor/bin/phpunit --colors=always`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composer.json
+git commit -m "refactor: remove Functions.php, fully migrated to Traits"
+```
+
+---
+
+## Task 20: 补充返回类型声明
+
+**Files:**
+- Modify: `src/Shortcut/Alipay/RefundShortcut.php`
+- Modify: `src/Shortcut/Alipay/QueryShortcut.php`
+- 其他需要检查的 Shortcut 文件
+
+- [ ] **Step 1: Check missing type declarations**
+
+Run: `./vendor/bin/phpstan analyse --memory-limit 300M -l 5 -c phpstan.neon ./src`
+Expected: 查看是否有缺少返回类型的警告
+
+- [ ] **Step 2: Fix RefundShortcut**
+
+```php
+// src/Shortcut/Alipay/RefundShortcut.php
+// 添加返回类型声明
+protected function defaultPlugins(): array  // 已有，检查确认
+protected function agreementPlugins(): array
+protected function appPlugins(): array
+// ... 其他方法
+```
+
+- [ ] **Step 3: Run analyse again**
+
+Run: `./vendor/bin/phpstan analyse --memory-limit 300M -l 5 -c phpstan.neon ./src`
+Expected: 无错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Shortcut/**/*.php
+git commit -m "fix: add missing return type declarations to Shortcut methods"
+```
+
+---
+
+## Task 21: 运行代码风格检查
+
+- [ ] **Step 1: Run cs-fix check**
+
+Run: `composer cs-fix`
+Expected: 无差异输出（或记录差异）
+
+- [ ] **Step 2: Fix style issues if any**
+
+如果有差异，手动修复或运行：
+```bash
+vendor/bin/php-cs-fixer fix src/
+```
+
+- [ ] **Step 3: Run cs-fix again to verify**
+
+Run: `composer cs-fix`
+Expected: 无差异
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/
+git commit -m "style: fix code style issues after refactoring"
+```
+
+---
+
+## Task 22: 最终验证
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `composer test`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run static analysis**
+
+Run: `composer analyse`
+Expected: Level 5 无错误
+
+- [ ] **Step 3: Run code style check**
+
+Run: `composer cs-fix`
+Expected: 无差异
+
+- [ ] **Step 4: Verify trait autoloading**
+
+```bash
+php -r "require 'vendor/autoload.php'; echo class_exists('Yansongda\\Pay\\CertManager') ? 'OK' : 'FAIL';"
+```
+Expected: OK
+
+---
+
+## Task 23: 更新 CHANGELOG
+
+- [ ] **Step 1: Add entry to CHANGELOG.md**
+
+```markdown
+## v3.8.0 - 2026-04-XX
+
+### Breaking Changes
+
+- **Functions.php 已删除**: 所有辅助函数迁移至 Trait，函数名改为驼峰命名
+  - `verify_alipay_sign` → `AlipayTrait::verifyAlipaySign()`
+  - `get_wechat_url` → `WechatTrait::getWechatUrl()`
+  - 等，详见迁移指南
+
+### 新增
+
+- `CertManager` 类：证书加载带进程内缓存
+- `ProviderConfigTrait`：getTenant、getProviderConfig、getRadarUrl
+- `AbstractServiceProvider`：ServiceProvider 抽象基类
+- 各 Provider Trait：AlipayTrait、WechatTrait、UnipayTrait、JsbTrait、DouyinTrait、PaypalTrait、StripeTrait
+
+### 优化
+
+- ServiceProvider 统一继承 AbstractServiceProvider
+- 补充 Shortcut 方法返回类型声明
+- 增加边界条件测试覆盖
+
+### 迁移指南
+
+原直接调用函数：
+```php
+use function Yansongda\Pay\verify_alipay_sign;
+verify_alipay_sign($config, $contents, $sign);
+```
+
+改为 Trait 方式：
+```php
+use Yansongda\Pay\Traits\AlipayTrait;
+// 在类中 use Trait
+class YourPlugin {
+    use AlipayTrait;
+    
+    // 调用
+    self::verifyAlipaySign($config, $contents, $sign);
+}
+```
+```
+
+- [ ] **Step 2: Commit CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG for v3.8.0"
+```
+
+---
+
+## 验收清单
+
+| 检查项 | 命令 | 预期结果 |
+|-------|------|---------|
+| 单元测试 | `composer test` | 全部 PASS |
+| 静态分析 | `composer analyse` | Level 5 无错误 |
+| 代码风格 | `composer cs-fix` | 无差异输出 |
+| 文件删除 | `ls src/Functions.php` | 文件不存在 |
+| Trait 存在 | `ls src/Traits/*.php` | 8 个文件 |
+| ServiceProvider | `grep -l "extends Abstract" src/Service/*.php` | 7 个匹配 |
+| CHANGELOG | `grep "v3.8.0" CHANGELOG.md` | 存在 |
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-15-code-refactoring.md`.**
+
+**执行选项：**
+
+**1. Subagent-Driven (推荐)** - 每个 Task 派发独立子代理，Task 间审查，快速迭代
+
+**2. Inline Execution** - 在当前会话批量执行，带审查检查点
+
+**请选择执行方式？**

--- a/docs/superpowers/specs/2026-04-15-code-refactoring-design.md
+++ b/docs/superpowers/specs/2026-04-15-code-refactoring-design.md
@@ -626,6 +626,7 @@ public function testClearCache(): void
 3. 添加边界条件测试
 4. 运行 `composer test` 确保全部通过
 5. 运行 `composer analyse` 确保无新增错误
+6. 运行 `composer cs-fix` 确保代码风格一致性（如有差异需修复）
 
 ---
 
@@ -652,6 +653,7 @@ public function testClearCache(): void
 |-------|------|
 | 单元测试 | `composer test` 全部通过 |
 | 静态分析 | `composer analyse` Level 5 无错误 |
+| 代码风格 | `composer cs-fix` 无差异输出 |
 | 代码覆盖率 | 新增 Trait 和边界测试覆盖率 > 80% |
 | 文件删除 | Functions.php 已删除 |
 | 类型声明 | 所有 Shortcut 方法有完整类型声明 |

--- a/docs/superpowers/specs/2026-04-15-code-refactoring-design.md
+++ b/docs/superpowers/specs/2026-04-15-code-refactoring-design.md
@@ -1,0 +1,697 @@
+# yansongda/pay 代码重构设计文档
+
+**日期**: 2026-04-15
+**版本**: v3.8.0（下一个 minor 版本）
+**影响范围**: Functions.php、ServiceProvider、证书缓存、类型声明、测试覆盖
+
+---
+
+## 一、概述
+
+本次重构针对 yansongda/pay SDK 的核心代码结构进行优化，涉及以下方面：
+
+1. **Functions.php 拆分** - 829 行辅助函数文件拆分为按 Provider 组织的 Trait
+2. **ServiceProvider 抽象** - 7 个重复的 ServiceProvider 统一为抽象基类
+3. **证书缓存机制** - 证书文件读取添加进程内缓存
+4. **类型声明补充** - Shortcut 方法添加返回类型声明
+5. **测试覆盖增强** - 添加签名验证失败、解密失败等边界条件测试
+
+**不处理项**：
+- HTTP 连接复用（保持现状，不在 SDK 层面处理）
+- 目录结构统一（暂时忽略）
+- 日志脱敏、证书权限检查等其他安全项（暂不处理）
+
+---
+
+## 二、Functions.php 拆分方案
+
+### 2.1 当前状态
+
+`src/Functions.php` 包含 829 行代码，包含以下函数分类：
+
+| 类别 | 函数数量 | 说明 |
+|------|---------|------|
+| 签名验证 | 8 | `verify_*_sign` 系列 |
+| URL 构建 | 7 | `get_*_url` 系列 |
+| 加解密 | 5 | 微信资源加解密 |
+| 证书处理 | 2 | `get_public_cert`、`get_private_cert` |
+| 配置获取 | 3 | `get_tenant`、`get_provider_config`、`get_radar_url` |
+| 其他 | 多个 | 微信支付签名、序列号获取等 |
+
+### 2.2 目标结构
+
+```
+src/Traits/
+├── AlipayTrait.php          # 支付宝相关函数
+├── WechatTrait.php          # 微信相关函数（最多）
+├── UnipayTrait.php          # 银联相关函数
+├── JsbTrait.php             # 江苏银行相关函数
+├── DouyinTrait.php          # 抖音相关函数
+├── PaypalTrait.php          # PayPal 相关函数
+├── StripeTrait.php          # Stripe 相关函数
+├── ProviderConfigTrait.php  # 配置获取（共享）
+
+src/CertManager.php          # 证书缓存（独立类，共享）
+```
+
+### 2.3 各 Trait 内容分配
+
+#### AlipayTrait
+
+```php
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Pay\CertManager;
+
+trait AlipayTrait
+{
+    /**
+     * 验证支付宝签名
+     */
+    public static function verifyAlipaySign(array $config, string $contents, string $sign): void
+    {
+        // ...
+        $public = CertManager::getPublicCert($config['alipay_public_cert_path']);
+        // ...
+    }
+    
+    /**
+     * 获取支付宝 API URL
+     */
+    public static function getAlipayUrl(array $config, ?Collection $payload): string;
+}
+```
+
+#### WechatTrait（最复杂）
+
+```php
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Pay\CertManager;
+
+trait WechatTrait
+{
+    // 签名验证（2个）
+    public static function verifyWechatSign(ResponseInterface|ServerRequestInterface $message, array $params): void;
+    public static function verifyWechatSignV2(array $config, array $destination): void;
+    
+    // URL/Body 获取（3个）
+    public static function getWechatMethod(?Collection $payload): string;
+    public static function getWechatUrl(array $config, ?Collection $payload): string;
+    public static function getWechatBody(?Collection $payload): mixed;
+    
+    // 签名生成（3个）
+    public static function getWechatSign(array $config, string $contents): string
+    {
+        $privateKey = CertManager::getPrivateCert($config['mch_secret_cert']);
+        // ...
+    }
+    public static function getWechatSignV2(array $config, array $payload, bool $upper = true): string;
+    public static function getWechatMiniprogramPaySign(array $config, string $url, string $payload): string;
+    
+    // 加解密（4个）
+    public static function encryptWechatContents(string $contents, string $publicKey): ?string
+    {
+        $publicKey = CertManager::getPublicCert($publicKey);
+        // ...
+    }
+    public static function decryptWechatContents(string $encrypted, array $config): ?string
+    {
+        $privateKey = CertManager::getPrivateCert($config['mch_secret_cert']);
+        // ...
+    }
+    public static function decryptWechatResource(array $resource, array $config): array;
+    public static function decryptWechatResourceAes256Gcm(...): array|string;
+    
+    // 证书管理（4个）
+    public static function reloadWechatPublicCerts(array $params, ?string $serialNo = null): string;
+    public static function getWechatPublicCerts(array $params = [], ?string $path = null): void;
+    public static function getWechatSerialNo(array $params): string;
+    public static function getWechatPublicKey(array $config, string $serialNo): string;
+    
+    // 其他（2个）
+    public static function getWechatTypeKey(array $params): string;
+    public static function getWechatMiniprogramUserSign(string $sessionKey, string $payload): string;
+}
+```
+
+#### UnipayTrait
+
+```php
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Pay\CertManager;
+
+trait UnipayTrait
+{
+    public static function verifyUnipaySign(array $config, string $contents, string $sign, ?string $signPublicKeyCert = null): void
+    {
+        $public = CertManager::getPublicCert($signPublicKeyCert ?? $config['unipay_public_cert_path']);
+        // ...
+    }
+    public static function verifyUnipaySignQra(array $config, array $destination): void;
+    public static function getUnipayUrl(array $config, ?Collection $payload): string;
+    public static function getUnipayBody(?Collection $payload): string;
+    public static function getUnipaySignQra(array $config, array $payload): string;
+}
+```
+
+#### JsbTrait
+
+```php
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Pay\CertManager;
+
+trait JsbTrait
+{
+    public static function verifyJsbSign(array $config, string $content, string $sign): void
+    {
+        $publicCert = CertManager::getPublicCert($config['jsb_public_cert_path']);
+        // ...
+    }
+    public static function getJsbUrl(array $config, ?Collection $payload): string;
+}
+```
+
+#### DouyinTrait
+
+```php
+trait DouyinTrait
+{
+    public static function getDouyinUrl(array $config, ?Collection $payload): string;
+}
+```
+
+#### PaypalTrait
+
+```php
+trait PaypalTrait
+{
+    public static function verifyPaypalWebhookSign(ServerRequestInterface $request, array $params): void;
+    public static function getPaypalUrl(array $config, ?Collection $payload): string;
+    public static function getPaypalAccessToken(array $params): string;
+}
+```
+
+#### StripeTrait
+
+```php
+trait StripeTrait
+{
+    public static function verifyStripeWebhookSign(ServerRequestInterface $request, array $params): void;
+    public static function getStripeUrl(array $config, ?Collection $payload): string;
+}
+```
+
+#### CertManager（独立类 - 证书缓存）
+
+```php
+namespace Yansongda\Pay;
+
+class CertManager
+{
+    private static array $cache = [];
+    
+    /**
+     * 获取公钥证书内容（带进程内缓存）
+     */
+    public static function getPublicCert(string $key): string
+    {
+        $cacheKey = 'public_' . md5($key);
+        
+        if (!isset(self::$cache[$cacheKey])) {
+            self::$cache[$cacheKey] = is_file($key) 
+                ? file_get_contents($key) 
+                : $key;
+        }
+        
+        return self::$cache[$cacheKey];
+    }
+    
+    /**
+     * 获取私钥证书内容（带进程内缓存）
+     */
+    public static function getPrivateCert(string $key): string
+    {
+        $cacheKey = 'private_' . md5($key);
+        
+        if (!isset(self::$cache[$cacheKey])) {
+            self::$cache[$cacheKey] = self::loadPrivateCert($key);
+        }
+        
+        return self::$cache[$cacheKey];
+    }
+    
+    private static function loadPrivateCert(string $key): string
+    {
+        if (is_file($key)) {
+            return file_get_contents($key);
+        }
+        
+        if (str_starts_with($key, '-----BEGIN PRIVATE KEY-----')) {
+            return $key;
+        }
+        
+        return "-----BEGIN RSA PRIVATE KEY-----\n"
+            . wordwrap($key, 64, "\n", true)
+            . "\n-----END RSA PRIVATE KEY-----";
+    }
+    
+    /**
+     * 清除证书缓存（用于测试）
+     */
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+}
+```
+
+#### ProviderConfigTrait（共享）
+
+```php
+namespace Yansongda\Pay\Traits;
+
+trait ProviderConfigTrait
+{
+    /**
+     * 获取租户标识
+     */
+    public static function getTenant(array $params = []): string
+    {
+        return strval($params['_config'] ?? 'default');
+    }
+    
+    /**
+     * 获取 Provider 配置
+     */
+    public static function getProviderConfig(string $provider, array $params = []): array
+    {
+        $config = Pay::get(ConfigInterface::class);
+        return $config->get($provider, [])[self::getTenant($params)] ?? [];
+    }
+    
+    /**
+     * 获取 Radar URL
+     */
+    public static function getRadarUrl(array $config, ?Collection $payload): ?string
+    {
+        return match ($config['mode'] ?? Pay::MODE_NORMAL) {
+            Pay::MODE_SERVICE => $payload?->get('_service_url') ?? $payload?->get('_url') ?? null,
+            Pay::MODE_SANDBOX => $payload?->get('_sandbox_url') ?? $payload?->get('_url') ?? null,
+            default => $payload?->get('_url') ?? null,
+        };
+    }
+}
+```
+
+### 2.4 函数命名变更
+
+Trait 中方法名改为 PSR 风格（驼峰命名）：
+
+| 原函数名 | 新方法名 |
+|---------|---------|
+| `verify_alipay_sign` | `verifyAlipaySign` |
+| `get_alipay_url` | `getAlipayUrl` |
+| `verify_wechat_sign` | `verifyWechatSign` |
+| `decrypt_wechat_resource` | `decryptWechatResource` |
+| ... | ... |
+
+### 2.5 调用方迁移
+
+所有使用 Functions.php 的代码改为使用 Trait：
+
+**Plugin 文件迁移示例**：
+
+```php
+// 修改前
+use function Yansongda\Pay\verify_alipay_sign;
+use function Yansongda\Pay\get_provider_config;
+
+// 修改后
+use Yansongda\Pay\Traits\AlipayTrait;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
+
+class CallbackPlugin implements PluginInterface
+{
+    use AlipayTrait;
+    use ProviderConfigTrait;
+    
+    public function assembly(Rocket $rocket, Closure $next): Rocket
+    {
+        $config = self::getProviderConfig('alipay', $params);
+        self::verifyAlipaySign($config, $contents, $sign);
+        // ...
+    }
+}
+```
+
+### 2.6 文件删除
+
+完成迁移后，**直接删除** `src/Functions.php`。
+
+---
+
+## 三、ServiceProvider 抽象基类
+
+### 3.1 当前状态
+
+7 个 ServiceProvider 文件结构完全相同（20-24 行）：
+
+```php
+class WechatServiceProvider implements ServiceProviderInterface
+{
+    public function register(mixed $data = null): void
+    {
+        $service = new Wechat();
+        Pay::set(Wechat::class, $service);
+        Pay::set('wechat', $service);
+    }
+}
+```
+
+### 3.2 抽象基类设计
+
+```php
+// src/Service/AbstractServiceProvider.php
+namespace Yansongda\Pay\Service;
+
+use Yansongda\Artful\Contract\ServiceProviderInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Pay\Pay;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * 返回 Provider 完整类名
+     */
+    abstract protected function getProviderClass(): string;
+    
+    /**
+     * 返回 Provider 注册名称（如 'wechat'）
+     */
+    abstract protected function getProviderName(): string;
+    
+    /**
+     * @throws ContainerException
+     */
+    public function register(mixed $data = null): void
+    {
+        $class = $this->getProviderClass();
+        $service = new $class();
+        
+        Pay::set($class, $service);
+        Pay::set($this->getProviderName(), $service);
+    }
+}
+```
+
+### 3.3 子类实现
+
+所有 ServiceProvider 改为继承基类：
+
+```php
+// src/Service/WechatServiceProvider.php
+class WechatServiceProvider extends AbstractServiceProvider
+{
+    protected function getProviderClass(): string
+    {
+        return Wechat::class;
+    }
+    
+    protected function getProviderName(): string
+    {
+        return 'wechat';
+    }
+}
+```
+
+同理修改：
+- AlipayServiceProvider
+- UnipayServiceProvider
+- JsbServiceProvider
+- DouyinServiceProvider
+- PaypalServiceProvider
+- StripeServiceProvider
+
+---
+
+## 四、类型声明补充
+
+### 4.1 受影响文件
+
+根据探索结果，以下文件的方法缺少返回类型声明：
+
+| 文件 | 缺少类型声明的方法数 |
+|-----|-------------------|
+| `src/Shortcut/Alipay/RefundShortcut.php` | 10 |
+| `src/Shortcut/Alipay/QueryShortcut.php` | 9 |
+| 其他 Shortcut 文件 | 需逐一检查 |
+
+### 4.2 修改示例
+
+```php
+// 修改前
+protected function defaultPlugins(): array
+{
+    return [...];
+}
+
+// 修改后 - 添加 : array（但实际已有，需要验证）
+protected function defaultPlugins(): array
+{
+    return [...];
+}
+```
+
+### 4.3 检查范围
+
+使用 PHPStan Level 5 验证所有类型声明完整性。
+
+---
+
+## 五、测试覆盖增强
+
+### 5.1 新增测试文件
+
+```
+tests/Traits/
+├── AlipayTraitTest.php          (新)
+├── WechatTraitTest.php          (新)
+├── UnipayTraitTest.php          (新)
+├── JsbTraitTest.php             (新)
+├── DouyinTraitTest.php          (新)
+├── PaypalTraitTest.php          (新)
+├── StripeTraitTest.php          (新)
+├── ProviderConfigTraitTest.php  (新)
+
+tests/CertManagerTest.php        (新 - 证书缓存类)
+```
+
+### 5.2 边界条件测试
+
+#### CallbackPlugin 测试增强
+
+**tests/Plugin/Alipay/V2/CallbackPluginTest.php**：
+
+```php
+public function testVerifySignWithEmptySign(): void
+{
+    $params = ['out_trade_no' => 'test', 'sign' => '']; // 空签名
+    
+    $this->expectException(InvalidSignException::class);
+    $this->expectExceptionCode(Exception::SIGN_EMPTY);
+    
+    Pay::alipay()->callback($params);
+}
+
+public function testVerifySignWithInvalidSign(): void
+{
+    $params = ['out_trade_no' => 'test', 'sign' => 'invalid_sign_string'];
+    
+    $this->expectException(InvalidSignException::class);
+    $this->expectExceptionCode(Exception::SIGN_ERROR);
+    
+    Pay::alipay()->callback($params);
+}
+
+public function testVerifySignWithMissingCertConfig(): void
+{
+    // 配置中缺少 alipay_public_cert_path
+    Pay::config(['alipay' => ['default' => ['app_id' => 'test']]]);
+    
+    $this->expectException(InvalidConfigException::class);
+    $this->expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
+    
+    Pay::alipay()->callback(['sign' => 'test']);
+}
+```
+
+**tests/Plugin/Wechat/V3/CallbackPluginTest.php**：
+
+```php
+public function testVerifySignWithEmptySignatureHeader(): void
+{
+    $request = new ServerRequest('POST', '/', [], json_encode(['test' => 'data']));
+    // 缺少 Wechatpay-Signature header
+    
+    $this->expectException(InvalidSignException::class);
+    $this->expectExceptionCode(Exception::SIGN_EMPTY);
+    
+    Pay::wechat()->callback($request);
+}
+
+public function testDecryptResourceWithInvalidCiphertext(): void
+{
+    // ciphertext 长度不足
+    $this->expectException(DecryptException::class);
+    $this->expectExceptionCode(Exception::DECRYPT_WECHAT_CIPHERTEXT_PARAMS_INVALID);
+    
+    // ... 测试代码
+}
+
+public function testDecryptResourceWithInvalidKey(): void
+{
+    // mch_secret_key 长度不正确
+    $this->expectException(InvalidConfigException::class);
+    $this->expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
+    
+    // ... 测试代码
+}
+```
+
+#### CertManager 测试
+
+```php
+// tests/CertManagerTest.php
+public function testGetPublicCertFromFile(): void
+{
+    $result = CertManager::getPublicCert(__DIR__ . '/Cert/test.crt');
+    $this->assertStringContainsString('BEGIN CERTIFICATE', $result);
+}
+
+public function testGetPublicCertFromString(): void
+{
+    $certContent = '-----BEGIN CERTIFICATE-----test-----END CERTIFICATE-----';
+    $result = CertManager::getPublicCert($certContent);
+    $this->assertEquals($certContent, $result);
+}
+
+public function testGetPublicCertCacheHit(): void
+{
+    $path = __DIR__ . '/Cert/test.crt';
+    
+    // 第一次调用
+    $result1 = CertManager::getPublicCert($path);
+    
+    // 第二次调用（应命中缓存）
+    $result2 = CertManager::getPublicCert($path);
+    
+    $this->assertEquals($result1, $result2);
+}
+
+public function testClearCache(): void
+{
+    CertManager::getPublicCert(__DIR__ . '/Cert/test.crt');
+    CertManager::clearCache();
+    
+    // 验证缓存已清空
+}
+```
+
+---
+
+## 六、实施顺序
+
+### Phase 1：基础设施（不破坏现有代码）
+
+1. 创建 `src/Traits/` 目录
+2. 创建 `CertHelperTrait.php`、`ProviderConfigTrait.php`
+3. 创建各 Provider Trait 文件（方法名使用驼峰）
+4. 创建 `src/Service/AbstractServiceProvider.php`
+
+### Phase 2：迁移调用方
+
+1. 修改所有 Plugin 文件，添加 `use Trait` 并改用 Trait 方法
+2. 修改 Provider 文件
+3. 修改 Shortcut 文件
+4. 补充返回类型声明
+5. 修改 ServiceProvider 继承抽象基类
+
+### Phase 3：清理与测试
+
+1. 删除 `src/Functions.php`
+2. 添加 Trait 测试文件
+3. 添加边界条件测试
+4. 运行 `composer test` 确保全部通过
+5. 运行 `composer analyse` 确保无新增错误
+
+---
+
+## 七、风险与回滚
+
+### 风险点
+
+1. **函数名变更** - 驼峰命名可能导致外部调用方需要更新（需在 CHANGELOG 中明确说明）
+2. **Functions.php 删除** - 直接删除，不保留 deprecated，依赖此文件的外部代码需自行迁移
+3. **缓存行为** - Swoole 常驻内存下证书缓存永不过期（可通过重启进程或调用 CertManager::clearCache() 刷新）
+
+### 回滚方案
+
+在主分支进行重构，通过 git 提交记录可随时回滚。发布前确保：
+- 所有测试通过
+- CHANGELOG.md 明确列出 Breaking Changes
+- 文档更新说明函数迁移方式
+
+---
+
+## 八、验收标准
+
+| 检查项 | 标准 |
+|-------|------|
+| 单元测试 | `composer test` 全部通过 |
+| 静态分析 | `composer analyse` Level 5 无错误 |
+| 代码覆盖率 | 新增 Trait 和边界测试覆盖率 > 80% |
+| 文件删除 | Functions.php 已删除 |
+| 类型声明 | 所有 Shortcut 方法有完整类型声明 |
+
+---
+
+## 九、附录：受影响文件清单
+
+### 新增文件
+
+| 文件路径 | 说明 |
+|---------|------|
+| `src/Traits/AlipayTrait.php` | 支付宝辅助方法 |
+| `src/Traits/WechatTrait.php` | 微信辅助方法 |
+| `src/Traits/UnipayTrait.php` | 银联辅助方法 |
+| `src/Traits/JsbTrait.php` | 江苏银行辅助方法 |
+| `src/Traits/DouyinTrait.php` | 抖音辅助方法 |
+| `src/Traits/PaypalTrait.php` | PayPal 辅助方法 |
+| `src/Traits/StripeTrait.php` | Stripe 辅助方法 |
+| `src/Traits/ProviderConfigTrait.php` | 配置获取（共享） |
+| `src/CertManager.php` | 证书缓存（独立类） |
+| `src/Service/AbstractServiceProvider.php` | ServiceProvider 抽象基类 |
+| `tests/Traits/*TraitTest.php` | Trait 测试（8个） |
+| `tests/CertManagerTest.php` | CertManager 测试 |
+
+### 修改文件
+
+| 文件路径 | 修改内容 |
+|---------|---------|
+| `src/Plugin/**/*.php` | 添加 Trait，替换函数调用 |
+| `src/Provider/*.php` | 添加 Trait，替换函数调用 |
+| `src/Shortcut/**/*.php` | 补充类型声明 |
+| `src/Service/*ServiceProvider.php` | 继承 AbstractServiceProvider（7个） |
+
+### 删除文件
+
+| 文件路径 | 说明 |
+|---------|------|
+| `src/Functions.php` | 辅助函数文件（829行） |
+
+---
+
+**设计文档完成，等待用户审核确认后进入实施计划阶段。**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,9 @@ parameters:
         - '#.* Illuminate\\Container\\Container.*#'
         - '#.* Hyperf\\Utils\\ApplicationContext.*#'
         - '#.* think\\Container.*#'
+        # v3.8 refactoring: Traits unused until subsequent PRs merge
+        - '#Trait Yansongda\\Pay\\Traits\\DouyinTrait is used zero times#'
+        - '#Trait Yansongda\\Pay\\Traits\\JsbTrait is used zero times#'
+        - '#Trait Yansongda\\Pay\\Traits\\PaypalTrait is used zero times#'
+        - '#Trait Yansongda\\Pay\\Traits\\UnipayTrait is used zero times#'
+        - '#Trait Yansongda\\Pay\\Traits\\WechatTrait is used zero times#'

--- a/src/CertManager.php
+++ b/src/CertManager.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay;
+
+use Yansongda\Supports\Str;
+
+class CertManager
+{
+    private static array $cache = [];
+
+    public static function getPublicCert(string $key): string
+    {
+        $cacheKey = 'public_'.md5($key);
+
+        if (isset(self::$cache[$cacheKey])) {
+            return self::$cache[$cacheKey];
+        }
+
+        $cert = is_file($key) ? file_get_contents($key) : $key;
+
+        self::$cache[$cacheKey] = $cert;
+
+        return $cert;
+    }
+
+    public static function getPrivateCert(string $key): string
+    {
+        $cacheKey = 'private_'.md5($key);
+
+        if (isset(self::$cache[$cacheKey])) {
+            return self::$cache[$cacheKey];
+        }
+
+        if (is_file($key)) {
+            $cert = file_get_contents($key);
+        } elseif (Str::startsWith($key, '-----BEGIN PRIVATE KEY-----')) {
+            $cert = $key;
+        } else {
+            $cert = "-----BEGIN RSA PRIVATE KEY-----\n"
+                .wordwrap($key, 64, "\n", true)
+                ."\n-----END RSA PRIVATE KEY-----";
+        }
+
+        self::$cache[$cacheKey] = $cert;
+
+        return $cert;
+    }
+
+    public static function clearCache(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/src/Plugin/Alipay/V2/AddPayloadSignaturePlugin.php
+++ b/src/Plugin/Alipay/V2/AddPayloadSignaturePlugin.php
@@ -11,13 +11,14 @@ use Yansongda\Artful\Exception\InvalidConfigException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Exception\Exception;
-
-use function Yansongda\Pay\get_private_cert;
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\AlipayTrait;
 
 class AddPayloadSignaturePlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -57,12 +58,12 @@ class AddPayloadSignaturePlugin implements PluginInterface
      */
     protected function getPrivateKey(array $params): string
     {
-        $privateKey = get_provider_config('alipay', $params)['app_secret_cert'] ?? null;
+        $privateKey = self::getProviderConfig('alipay', $params)['app_secret_cert'] ?? null;
 
         if (is_null($privateKey)) {
             throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, '配置异常: 缺少支付宝配置 -- [app_secret_cert]');
         }
 
-        return get_private_cert($privateKey);
+        return CertManager::getPrivateCert($privateKey);
     }
 }

--- a/src/Plugin/Alipay/V2/AddRadarPlugin.php
+++ b/src/Plugin/Alipay/V2/AddRadarPlugin.php
@@ -12,14 +12,15 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\AlipayTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\get_radar_method;
-use function Yansongda\Pay\get_alipay_url;
-use function Yansongda\Pay\get_provider_config;
 
 class AddRadarPlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -29,13 +30,13 @@ class AddRadarPlugin implements PluginInterface
         Logger::debug('[Alipay][AddRadarPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('alipay', $params);
+        $config = self::getProviderConfig('alipay', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setRadar(new Request(
             // 这里因为支付宝的 payload 里不包含 _method，所以需要取 params 中的
             get_radar_method(new Collection($params)) ?? 'POST',
-            get_alipay_url($config, $payload),
+            self::getAlipayUrl($config, $payload),
             $this->getHeaders($params),
             // 不能用 artful 中 get_radar_body 方法
             // 来自 AddPayloadBodyPlugin 插件通过 packer 生成的 _body

--- a/src/Plugin/Alipay/V2/AppCallbackPlugin.php
+++ b/src/Plugin/Alipay/V2/AppCallbackPlugin.php
@@ -15,13 +15,14 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\AlipayTrait;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\verify_alipay_sign;
 
 class AppCallbackPlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -34,7 +35,7 @@ class AppCallbackPlugin implements PluginInterface
         Logger::debug('[Alipay][AppCallbackPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('alipay', $params);
+        $config = self::getProviderConfig('alipay', $params);
 
         if (empty($params['alipay_trade_app_pay_response'])) {
             throw new InvalidParamsException(Exception::PARAMS_CALLBACK_REQUEST_INVALID);
@@ -42,7 +43,7 @@ class AppCallbackPlugin implements PluginInterface
 
         $value = filter_params($params['alipay_trade_app_pay_response']);
 
-        verify_alipay_sign($config, $value->toJson(), $params['sign'] ?? '');
+        self::verifyAlipaySign($config, $value->toJson(), $params['sign'] ?? '');
 
         $rocket->setPayload($params)
             ->setDirection(NoHttpRequestDirection::class)

--- a/src/Plugin/Alipay/V2/CallbackPlugin.php
+++ b/src/Plugin/Alipay/V2/CallbackPlugin.php
@@ -13,13 +13,14 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\AlipayTrait;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\verify_alipay_sign;
 
 class CallbackPlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -31,11 +32,11 @@ class CallbackPlugin implements PluginInterface
         Logger::debug('[Alipay][CallbackPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('alipay', $params);
+        $config = self::getProviderConfig('alipay', $params);
 
         $value = filter_params($params, fn ($k, $v) => '' !== $v && 'sign' != $k && 'sign_type' != $k);
 
-        verify_alipay_sign($config, $value->sortKeys()->toString(), $params['sign'] ?? '');
+        self::verifyAlipaySign($config, $value->sortKeys()->toString(), $params['sign'] ?? '');
 
         $rocket->setPayload($params)
             ->setDirection(NoHttpRequestDirection::class)

--- a/src/Plugin/Alipay/V2/StartPlugin.php
+++ b/src/Plugin/Alipay/V2/StartPlugin.php
@@ -12,15 +12,15 @@ use Yansongda\Artful\Exception\InvalidConfigException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_public_cert;
-use function Yansongda\Pay\get_tenant;
+use Yansongda\Pay\Traits\AlipayTrait;
 
 class StartPlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -44,8 +44,8 @@ class StartPlugin implements PluginInterface
      */
     protected function getPayload(array $params): array
     {
-        $tenant = get_tenant($params);
-        $config = get_provider_config('alipay', $params);
+        $tenant = self::getTenant($params);
+        $config = self::getProviderConfig('alipay', $params);
 
         return [
             'app_id' => $config['app_id'] ?? '',
@@ -109,7 +109,7 @@ class StartPlugin implements PluginInterface
             throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, '配置异常: 缺少支付宝配置 -- [app_public_cert_path]');
         }
 
-        $ssl = openssl_x509_parse(get_public_cert($path));
+        $ssl = openssl_x509_parse(CertManager::getPublicCert($path));
 
         if (false === $ssl) {
             throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, '配置异常: 解析 `app_public_cert_path` 失败');
@@ -140,7 +140,7 @@ class StartPlugin implements PluginInterface
         }
 
         $sn = '';
-        $exploded = explode('-----END CERTIFICATE-----', get_public_cert($path));
+        $exploded = explode('-----END CERTIFICATE-----', CertManager::getPublicCert($path));
 
         foreach ($exploded as $cert) {
             if (empty(trim($cert))) {

--- a/src/Plugin/Alipay/V2/VerifySignaturePlugin.php
+++ b/src/Plugin/Alipay/V2/VerifySignaturePlugin.php
@@ -14,14 +14,15 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\AlipayTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\should_do_http_request;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\verify_alipay_sign;
 
 class VerifySignaturePlugin implements PluginInterface
 {
+    use AlipayTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -46,9 +47,9 @@ class VerifySignaturePlugin implements PluginInterface
             throw new InvalidParamsException(Exception::RESPONSE_EMPTY, '参数异常: 支付宝验证签名时待验签参数不正确', $destination);
         }
 
-        $config = get_provider_config('alipay', $rocket->getParams());
+        $config = self::getProviderConfig('alipay', $rocket->getParams());
 
-        verify_alipay_sign($config, json_encode($result, JSON_UNESCAPED_UNICODE), $destination->get('_sign', ''));
+        self::verifyAlipaySign($config, json_encode($result, JSON_UNESCAPED_UNICODE), $destination->get('_sign', ''));
 
         Logger::info('[Alipay][VerifySignaturePlugin] 插件装载完毕', ['rocket' => $rocket]);
 

--- a/src/Plugin/Stripe/V1/AddRadarPlugin.php
+++ b/src/Plugin/Stripe/V1/AddRadarPlugin.php
@@ -12,15 +12,16 @@ use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\StripeTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
 use function Yansongda\Artful\get_radar_method;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_stripe_url;
 
 class AddRadarPlugin implements PluginInterface
 {
+    use StripeTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,11 +33,11 @@ class AddRadarPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('stripe', $params);
+        $config = self::getProviderConfig('stripe', $params);
 
         $rocket->setRadar(new Request(
             get_radar_method($payload),
-            get_stripe_url($config, $payload).$this->getQueryString($payload),
+            self::getStripeUrl($config, $payload).$this->getQueryString($payload),
             $this->getHeaders($config, $payload),
             $this->getBody($payload),
         ));

--- a/src/Plugin/Stripe/V1/Pay/CallbackPlugin.php
+++ b/src/Plugin/Stripe/V1/Pay/CallbackPlugin.php
@@ -16,12 +16,13 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\StripeTrait;
 use Yansongda\Supports\Collection;
-
-use function Yansongda\Pay\verify_stripe_webhook_sign;
 
 class CallbackPlugin implements PluginInterface
 {
+    use StripeTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -36,7 +37,7 @@ class CallbackPlugin implements PluginInterface
         $this->init($rocket);
 
         /* @phpstan-ignore-next-line */
-        verify_stripe_webhook_sign($rocket->getDestinationOrigin(), $rocket->getParams());
+        self::verifyStripeWebhookSign($rocket->getDestinationOrigin(), $rocket->getParams());
 
         $bodyString = (string) $rocket->getDestination()->getBody();
         $body = json_decode($bodyString, true);

--- a/src/Plugin/Stripe/V1/Pay/WebPlugin.php
+++ b/src/Plugin/Stripe/V1/Pay/WebPlugin.php
@@ -11,14 +11,15 @@ use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
-
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\StripeTrait;
 
 /**
  * @see https://stripe.com/docs/api/checkout/sessions/create
  */
 class WebPlugin implements PluginInterface
 {
+    use StripeTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -30,7 +31,7 @@ class WebPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('stripe', $params);
+        $config = self::getProviderConfig('stripe', $params);
 
         $rocket->mergePayload([
             '_method' => 'POST',

--- a/src/Service/AbstractServiceProvider.php
+++ b/src/Service/AbstractServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Service;
+
+use Yansongda\Artful\Contract\ServiceProviderInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Pay\Pay;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @throws ContainerException
+     */
+    public function register(mixed $data = null): void
+    {
+        $class = $this->getProviderClass();
+        $service = new $class();
+
+        Pay::set($class, $service);
+        Pay::set($this->getProviderName(), $service);
+    }
+
+    abstract protected function getProviderClass(): string;
+
+    abstract protected function getProviderName(): string;
+}

--- a/src/Traits/AlipayTrait.php
+++ b/src/Traits/AlipayTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Provider\Alipay;
+use Yansongda\Supports\Collection;
+
+trait AlipayTrait
+{
+    use ProviderConfigTrait;
+
+    public static function verifyAlipaySign(array $config, string $contents, string $sign): void
+    {
+        if ('' === $sign) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY);
+        }
+
+        if (empty($config['alipay_public_cert_path'])) {
+            throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, '配置异常: 缺少支付宝配置 -- [alipay_public_cert_path]');
+        }
+
+        $publicCert = CertManager::getPublicCert((string) $config['alipay_public_cert_path']);
+        $publicKey = openssl_pkey_get_public($publicCert);
+
+        if (false === $publicKey || 1 !== openssl_verify($contents, base64_decode($sign), $publicKey, OPENSSL_ALGO_SHA256)) {
+            throw new InvalidSignException(Exception::SIGN_ERROR);
+        }
+    }
+
+    public static function getAlipayUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (is_string($url) && str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Alipay::URL[$config['mode'] ?? Pay::MODE_NORMAL];
+    }
+}

--- a/src/Traits/DouyinTrait.php
+++ b/src/Traits/DouyinTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Provider\Douyin;
+use Yansongda\Supports\Collection;
+
+trait DouyinTrait
+{
+    use ProviderConfigTrait;
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getDouyinUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_DOUYIN_URL_MISSING, '参数异常: 抖音 `_url` 参数缺失：你可能用错插件顺序，应该先使用 `业务插件`');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Douyin::URL[$config['mode'] ?? Pay::MODE_NORMAL].$url;
+    }
+}

--- a/src/Traits/JsbTrait.php
+++ b/src/Traits/JsbTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Provider\Jsb;
+use Yansongda\Supports\Collection;
+
+trait JsbTrait
+{
+    use ProviderConfigTrait;
+
+    public static function getJsbUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload) ?? '';
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Jsb::URL[$config['mode'] ?? Pay::MODE_NORMAL];
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyJsbSign(array $config, string $content, string $sign): void
+    {
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 江苏银行签名为空', func_get_args());
+        }
+
+        $publicCert = $config['jsb_public_cert_path'] ?? null;
+
+        if (empty($publicCert)) {
+            throw new InvalidConfigException(Exception::CONFIG_JSB_INVALID, '配置异常: 缺少配置参数 -- [jsb_public_cert_path]');
+        }
+
+        $result = 1 === openssl_verify(
+            $content,
+            base64_decode($sign),
+            CertManager::getPublicCert($publicCert)
+        );
+
+        if (!$result) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证江苏银行签名失败', func_get_args());
+        }
+    }
+}

--- a/src/Traits/PaypalTrait.php
+++ b/src/Traits/PaypalTrait.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Yansongda\Artful\Artful;
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Artful\Plugin\ParserPlugin;
+use Yansongda\Artful\Plugin\StartPlugin;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Plugin\Paypal\V2\AddRadarPlugin;
+use Yansongda\Pay\Plugin\Paypal\V2\GetAccessTokenPlugin;
+use Yansongda\Pay\Plugin\Paypal\V2\ResponsePlugin;
+use Yansongda\Pay\Plugin\Paypal\V2\VerifyWebhookSignPlugin;
+use Yansongda\Pay\Provider\Paypal;
+use Yansongda\Supports\Collection;
+
+trait PaypalTrait
+{
+    use ProviderConfigTrait;
+
+    public static function getPaypalUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_PAYPAL_URL_MISSING, '参数异常: PayPal `_url` 参数缺失：你可能用错插件顺序，应该先使用 `业务插件`');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Paypal::URL[$config['mode'] ?? Pay::MODE_NORMAL].$url;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws ServiceNotFoundException
+     */
+    public static function getPaypalAccessToken(array $params): string
+    {
+        $config = self::getProviderConfig('paypal', $params);
+
+        if (!empty($config['_access_token'])
+            && !empty($config['_access_token_expiry'])
+            && time() < (int) $config['_access_token_expiry']) {
+            return $config['_access_token'];
+        }
+
+        if (empty($config['client_id']) || empty($config['app_secret'])) {
+            throw new InvalidConfigException(Exception::CONFIG_PAYPAL_INVALID, '配置异常: 缺少 PayPal 配置 -- [client_id] or [app_secret]');
+        }
+
+        $result = Artful::artful([
+            StartPlugin::class,
+            GetAccessTokenPlugin::class,
+            AddRadarPlugin::class,
+            ResponsePlugin::class,
+            ParserPlugin::class,
+        ], $params);
+
+        $token = $result->get('access_token', '');
+        $expiresIn = $result->get('expires_in', 32400);
+
+        Pay::get(ConfigInterface::class)->set(
+            'paypal.'.self::getTenant($params).'._access_token',
+            $token
+        );
+        Pay::get(ConfigInterface::class)->set(
+            'paypal.'.self::getTenant($params).'._access_token_expiry',
+            time() + $expiresIn - 60
+        );
+
+        return $token;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws InvalidSignException
+     * @throws ServiceNotFoundException
+     */
+    public static function verifyPaypalWebhookSign(ServerRequestInterface $request, array $params): void
+    {
+        $config = self::getProviderConfig('paypal', $params);
+
+        $webhookId = $config['webhook_id'] ?? null;
+
+        if (empty($webhookId)) {
+            throw new InvalidConfigException(Exception::CONFIG_PAYPAL_INVALID, '配置异常: 缺少 PayPal 配置 -- [webhook_id]');
+        }
+
+        $transmissionId = $request->getHeaderLine('PAYPAL-TRANSMISSION-ID');
+        $transmissionTime = $request->getHeaderLine('PAYPAL-TRANSMISSION-TIME');
+        $transmissionSig = $request->getHeaderLine('PAYPAL-TRANSMISSION-SIG');
+        $certUrl = $request->getHeaderLine('PAYPAL-CERT-URL');
+        $authAlgo = $request->getHeaderLine('PAYPAL-AUTH-ALGO');
+        $body = (string) $request->getBody();
+
+        if (empty($transmissionId) || empty($transmissionSig)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: PayPal 回调签名为空', ['headers' => $request->getHeaders(), 'body' => $body]);
+        }
+
+        $webhookEvent = json_decode($body, true);
+
+        $verifyPayload = [
+            'auth_algo' => $authAlgo,
+            'cert_url' => $certUrl,
+            'transmission_id' => $transmissionId,
+            'transmission_sig' => $transmissionSig,
+            'transmission_time' => $transmissionTime,
+            'webhook_id' => $webhookId,
+            'webhook_event' => $webhookEvent,
+        ];
+
+        $token = self::getPaypalAccessToken($params);
+        $url = Paypal::URL[$config['mode'] ?? Pay::MODE_NORMAL].'v1/notifications/verify-webhook-signature';
+
+        $result = Artful::artful([
+            StartPlugin::class,
+            VerifyWebhookSignPlugin::class,
+            AddRadarPlugin::class,
+            ResponsePlugin::class,
+            ParserPlugin::class,
+        ], array_merge($params, [
+            '_verify_url' => $url,
+            '_verify_body' => json_encode($verifyPayload),
+            '_access_token' => $token,
+        ]));
+
+        $status = $result->get('verification_status', '');
+
+        if ('SUCCESS' !== $status) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证 PayPal 回调签名失败', ['headers' => $request->getHeaders(), 'body' => $body, 'verification_status' => $status]);
+        }
+    }
+}

--- a/src/Traits/ProviderConfigTrait.php
+++ b/src/Traits/ProviderConfigTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Pay\Pay;
+use Yansongda\Supports\Collection;
+
+trait ProviderConfigTrait
+{
+    public static function getTenant(array $params = []): string
+    {
+        return (string) ($params['_config'] ?? 'default');
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws ServiceNotFoundException
+     */
+    public static function getProviderConfig(string $provider, array $params = []): array
+    {
+        /** @var ConfigInterface $config */
+        $config = Pay::get(ConfigInterface::class);
+
+        return $config->get($provider, [])[self::getTenant($params)] ?? [];
+    }
+
+    public static function getRadarUrl(array $config, ?Collection $payload): ?string
+    {
+        if (null === $payload) {
+            return null;
+        }
+
+        return match ($config['mode'] ?? Pay::MODE_NORMAL) {
+            Pay::MODE_SERVICE => $payload->get('_service_url', $payload->get('_url')),
+            Pay::MODE_SANDBOX => $payload->get('_sandbox_url', $payload->get('_url')),
+            default => $payload->get('_url'),
+        };
+    }
+}

--- a/src/Traits/StripeTrait.php
+++ b/src/Traits/StripeTrait.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Provider\Stripe;
+use Yansongda\Supports\Collection;
+
+trait StripeTrait
+{
+    use ProviderConfigTrait;
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getStripeUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_STRIPE_URL_MISSING, '参数异常: Stripe `_url` 参数缺失：你可能用错插件顺序，应该先使用 `业务插件`');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Stripe::URL[$config['mode'] ?? Pay::MODE_NORMAL].$url;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     * @throws ServiceNotFoundException
+     */
+    public static function verifyStripeWebhookSign(ServerRequestInterface $request, array $params): void
+    {
+        $config = self::getProviderConfig('stripe', $params);
+        $webhookSecret = $config['webhook_secret'] ?? null;
+
+        if (empty($webhookSecret)) {
+            throw new InvalidConfigException(Exception::CONFIG_STRIPE_INVALID, '配置异常: 缺少 Stripe 配置 -- [webhook_secret]');
+        }
+
+        $signatureHeader = $request->getHeaderLine('Stripe-Signature');
+        $body = (string) $request->getBody();
+
+        if (empty($signatureHeader)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: Stripe 回调签名为空', ['headers' => $request->getHeaders(), 'body' => $body]);
+        }
+
+        $parts = explode(',', $signatureHeader);
+        $timestamp = null;
+        $signatures = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+
+            if ('' === $part) {
+                continue;
+            }
+
+            $pair = explode('=', $part, 2);
+
+            if (2 !== count($pair)) {
+                continue;
+            }
+
+            [$key, $value] = $pair;
+            $key = trim($key);
+            $value = trim($value);
+
+            if ('t' === $key) {
+                $timestamp = $value;
+            } elseif ('v1' === $key) {
+                $signatures[] = $value;
+            }
+        }
+
+        if (empty($timestamp) || empty($signatures)) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: Stripe 回调签名格式错误', ['headers' => $request->getHeaders(), 'body' => $body]);
+        }
+
+        if (abs(time() - (int) $timestamp) > 300) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: Stripe 回调签名时间戳超时', ['timestamp' => $timestamp]);
+        }
+
+        $signedPayload = $timestamp.'.'.$body;
+        $expectedSignature = hash_hmac('sha256', $signedPayload, $webhookSecret);
+
+        foreach ($signatures as $signature) {
+            if (hash_equals($expectedSignature, $signature)) {
+                return;
+            }
+        }
+
+        throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证 Stripe 回调签名失败', ['headers' => $request->getHeaders(), 'body' => $body]);
+    }
+}

--- a/src/Traits/SupportServiceProviderTrait.php
+++ b/src/Traits/SupportServiceProviderTrait.php
@@ -9,10 +9,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Pay;
 
-use function Yansongda\Pay\get_provider_config;
-
 trait SupportServiceProviderTrait
 {
+    use ProviderConfigTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -20,7 +20,7 @@ trait SupportServiceProviderTrait
     protected function loadAlipayServiceProvider(Rocket $rocket): void
     {
         $params = $rocket->getParams();
-        $config = get_provider_config('alipay', $params);
+        $config = self::getProviderConfig('alipay', $params);
         $serviceProviderId = $config['service_provider_id'] ?? null;
 
         if (Pay::MODE_SERVICE !== ($config['mode'] ?? Pay::MODE_NORMAL)

--- a/src/Traits/UnipayTrait.php
+++ b/src/Traits/UnipayTrait.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Provider\Unipay;
+use Yansongda\Supports\Collection;
+
+use function Yansongda\Artful\get_radar_body;
+
+trait UnipayTrait
+{
+    use ProviderConfigTrait;
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getUnipayUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_UNIPAY_URL_MISSING, '参数异常: 银联 `_url` 参数缺失：你可能用错插件顺序，应该先使用 `业务插件`');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Unipay::URL[$config['mode'] ?? Pay::MODE_NORMAL].$url;
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getUnipayBody(?Collection $payload): string
+    {
+        $body = get_radar_body($payload);
+
+        if (is_null($body)) {
+            throw new InvalidParamsException(Exception::PARAMS_UNIPAY_BODY_MISSING, '参数异常: 银联 `_body` 参数缺失：你可能用错插件顺序，应该先使用 `AddPayloadBodyPlugin`');
+        }
+
+        return $body;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyUnipaySign(array $config, string $contents, string $sign, ?string $signPublicKeyCert = null): void
+    {
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 银联签名为空', func_get_args());
+        }
+
+        if (empty($signPublicKeyCert) && empty($public = $config['unipay_public_cert_path'] ?? null)) {
+            throw new InvalidConfigException(Exception::CONFIG_UNIPAY_INVALID, '配置异常： 缺少银联配置 -- [unipay_public_cert_path]');
+        }
+
+        $result = 1 === openssl_verify(
+            hash('sha256', $contents),
+            base64_decode($sign),
+            CertManager::getPublicCert($signPublicKeyCert ?? $public),
+            'sha256'
+        );
+
+        if (!$result) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证银联签名失败', func_get_args());
+        }
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getUnipaySignQra(array $config, array $payload): string
+    {
+        $key = $config['mch_secret_key'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_UNIPAY_INVALID, '配置异常: 缺少银联配置 -- [mch_secret_key]');
+        }
+
+        ksort($payload);
+
+        $buff = '';
+
+        foreach ($payload as $k => $v) {
+            $buff .= ('sign' != $k && '' != $v && !is_array($v)) ? $k.'='.$v.'&' : '';
+        }
+
+        return strtoupper(md5($buff.'key='.$key));
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyUnipaySignQra(array $config, array $destination): void
+    {
+        $sign = $destination['sign'] ?? null;
+
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 银联签名为空', $destination);
+        }
+
+        $key = $config['mch_secret_key'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_UNIPAY_INVALID, '配置异常: 缺少银联配置 -- [mch_secret_key]');
+        }
+
+        if (self::getUnipaySignQra($config, $destination) !== $sign) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证银联签名失败', $destination);
+        }
+    }
+}

--- a/src/Traits/WechatTrait.php
+++ b/src/Traits/WechatTrait.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Traits;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Exception\ContainerException;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Artful\Plugin\AddPayloadBodyPlugin;
+use Yansongda\Artful\Plugin\ParserPlugin;
+use Yansongda\Artful\Plugin\StartPlugin;
+use Yansongda\Pay\CertManager;
+use Yansongda\Pay\Exception\DecryptException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Plugin\Wechat\AddRadarPlugin;
+use Yansongda\Pay\Plugin\Wechat\ResponsePlugin;
+use Yansongda\Pay\Plugin\Wechat\V3\AddPayloadSignaturePlugin;
+use Yansongda\Pay\Plugin\Wechat\V3\WechatPublicCertsPlugin;
+use Yansongda\Pay\Provider\Wechat;
+use Yansongda\Supports\Collection;
+
+use function Yansongda\Artful\get_radar_body;
+use function Yansongda\Artful\get_radar_method;
+
+trait WechatTrait
+{
+    use ProviderConfigTrait;
+
+    public static function getWechatMethod(?Collection $payload): string
+    {
+        return get_radar_method($payload) ?? 'POST';
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatUrl(array $config, ?Collection $payload): string
+    {
+        $url = self::getRadarUrl($config, $payload);
+
+        if (empty($url)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_URL_MISSING, '参数异常: 微信 `_url` 或 `_service_url` 参数缺失：你可能用错插件顺序，应该先使用 `业务插件`');
+        }
+
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return Wechat::URL[$config['mode'] ?? Pay::MODE_NORMAL].$url;
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatBody(?Collection $payload): mixed
+    {
+        $body = get_radar_body($payload);
+
+        if (is_null($body)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_BODY_MISSING, '参数异常: 微信 `_body` 参数缺失：你可能用错插件顺序，应该先使用 `AddPayloadBodyPlugin`');
+        }
+
+        return $body;
+    }
+
+    public static function getWechatTypeKey(array $params): string
+    {
+        $key = ($params['_type'] ?? 'mp').'_app_id';
+
+        if ('app_app_id' === $key) {
+            $key = 'app_id';
+        }
+
+        return $key;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatSign(array $config, string $contents): string
+    {
+        $privateKey = $config['mch_secret_cert'] ?? null;
+
+        if (empty($privateKey)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_cert]');
+        }
+
+        $privateKey = CertManager::getPrivateCert($privateKey);
+
+        openssl_sign($contents, $sign, $privateKey, 'sha256WithRSAEncryption');
+
+        return base64_encode($sign);
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatSignV2(array $config, array $payload, bool $upper = true): string
+    {
+        $key = $config['mch_secret_key_v2'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key_v2]');
+        }
+
+        ksort($payload);
+
+        $buff = '';
+
+        foreach ($payload as $k => $v) {
+            $buff .= ('sign' != $k && '' != $v && !is_array($v)) ? $k.'='.$v.'&' : '';
+        }
+
+        $sign = md5($buff.'key='.$key);
+
+        return $upper ? strtoupper($sign) : $sign;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws DecryptException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws InvalidSignException
+     * @throws ServiceNotFoundException
+     */
+    public static function verifyWechatSign(ResponseInterface|ServerRequestInterface $message, array $params): void
+    {
+        $wechatSerial = $message->getHeaderLine('Wechatpay-Serial');
+        $timestamp = $message->getHeaderLine('Wechatpay-Timestamp');
+        $random = $message->getHeaderLine('Wechatpay-Nonce');
+        $sign = $message->getHeaderLine('Wechatpay-Signature');
+        $body = (string) $message->getBody();
+
+        $content = $timestamp."\n".$random."\n".$body."\n";
+        $public = self::getProviderConfig('wechat', $params)['wechat_public_cert_path'][$wechatSerial] ?? null;
+
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 微信签名为空', ['headers' => $message->getHeaders(), 'body' => $body]);
+        }
+
+        $public = CertManager::getPublicCert(
+            empty($public) ? self::reloadWechatPublicCerts($params, $wechatSerial) : $public
+        );
+
+        $result = 1 === openssl_verify(
+            $content,
+            base64_decode($sign),
+            $public,
+            'sha256WithRSAEncryption'
+        );
+
+        if (!$result) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证微信签名失败', ['headers' => $message->getHeaders(), 'body' => $body]);
+        }
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws InvalidSignException
+     */
+    public static function verifyWechatSignV2(array $config, array $destination): void
+    {
+        $sign = $destination['sign'] ?? null;
+
+        if (empty($sign)) {
+            throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 微信签名为空', $destination);
+        }
+
+        $key = $config['mch_secret_key_v2'] ?? null;
+
+        if (empty($key)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key_v2]');
+        }
+
+        if (self::getWechatSignV2($config, $destination) !== $sign) {
+            throw new InvalidSignException(Exception::SIGN_ERROR, '签名异常: 验证微信签名失败', $destination);
+        }
+    }
+
+    public static function encryptWechatContents(string $contents, string $publicKey): ?string
+    {
+        if (openssl_public_encrypt($contents, $encrypted, CertManager::getPublicCert($publicKey), OPENSSL_PKCS1_OAEP_PADDING)) {
+            return base64_encode($encrypted);
+        }
+
+        return null;
+    }
+
+    public static function decryptWechatContents(string $encrypted, array $config): ?string
+    {
+        if (openssl_private_decrypt(base64_decode($encrypted), $decrypted, CertManager::getPrivateCert($config['mch_secret_cert'] ?? ''), OPENSSL_PKCS1_OAEP_PADDING)) {
+            return $decrypted;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws DecryptException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws ServiceNotFoundException
+     */
+    public static function reloadWechatPublicCerts(array $params, ?string $serialNo = null): string
+    {
+        $data = Pay::wechat()->pay(
+            [StartPlugin::class, WechatPublicCertsPlugin::class, AddPayloadBodyPlugin::class, AddPayloadSignaturePlugin::class, AddRadarPlugin::class, ResponsePlugin::class, ParserPlugin::class],
+            $params
+        )->get('data', []);
+
+        $wechatConfig = self::getProviderConfig('wechat', $params);
+
+        foreach ($data as $item) {
+            $certs[$item['serial_no']] = self::decryptWechatResource($item['encrypt_certificate'], $wechatConfig)['ciphertext'] ?? '';
+        }
+
+        Pay::get(ConfigInterface::class)->set(
+            'wechat.'.self::getTenant($params).'.wechat_public_cert_path',
+            ((array) ($wechatConfig['wechat_public_cert_path'] ?? [])) + ($certs ?? []),
+        );
+
+        if (!is_null($serialNo) && empty($certs[$serialNo])) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 获取微信 wechat_public_cert_path 配置失败');
+        }
+
+        return $certs[$serialNo] ?? '';
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws DecryptException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws ServiceNotFoundException
+     */
+    public static function getWechatPublicCerts(array $params = [], ?string $path = null): void
+    {
+        self::reloadWechatPublicCerts($params);
+
+        $config = self::getProviderConfig('wechat', $params);
+
+        if (empty($path)) {
+            var_dump($config['wechat_public_cert_path']);
+
+            return;
+        }
+
+        foreach ($config['wechat_public_cert_path'] as $serialNo => $cert) {
+            file_put_contents($path.'/'.$serialNo.'.crt', $cert);
+        }
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws DecryptException
+     */
+    public static function decryptWechatResource(array $resource, array $config): array
+    {
+        $ciphertext = base64_decode($resource['ciphertext'] ?? '');
+        $secret = $config['mch_secret_key'] ?? null;
+
+        if (strlen($ciphertext) <= Wechat::AUTH_TAG_LENGTH_BYTE) {
+            throw new DecryptException(Exception::DECRYPT_WECHAT_CIPHERTEXT_PARAMS_INVALID, '加解密异常: ciphertext 位数过短');
+        }
+
+        if (is_null($secret) || Wechat::MCH_SECRET_KEY_LENGTH_BYTE != strlen($secret)) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mch_secret_key]');
+        }
+
+        $resource['ciphertext'] = match ($resource['algorithm'] ?? '') {
+            'AEAD_AES_256_GCM' => self::decryptWechatResourceAes256Gcm($ciphertext, $secret, $resource['nonce'] ?? '', $resource['associated_data'] ?? ''),
+            default => throw new DecryptException(Exception::DECRYPT_WECHAT_DECRYPTED_METHOD_INVALID, '加解密异常: algorithm 不支持'),
+        };
+
+        return $resource;
+    }
+
+    /**
+     * @throws DecryptException
+     */
+    public static function decryptWechatResourceAes256Gcm(string $ciphertext, string $secret, string $nonce, string $associatedData): array|string
+    {
+        $decrypted = openssl_decrypt(
+            substr($ciphertext, 0, -Wechat::AUTH_TAG_LENGTH_BYTE),
+            'aes-256-gcm',
+            $secret,
+            OPENSSL_RAW_DATA,
+            $nonce,
+            substr($ciphertext, -Wechat::AUTH_TAG_LENGTH_BYTE),
+            $associatedData
+        );
+
+        if (false === $decrypted) {
+            throw new DecryptException(Exception::DECRYPT_WECHAT_ENCRYPTED_DATA_INVALID, '加解密异常: 解密失败，请检查微信 mch_secret_key 是否正确');
+        }
+
+        if ('certificate' !== $associatedData) {
+            $decrypted = json_decode($decrypted, true);
+
+            if (JSON_ERROR_NONE !== json_last_error()) {
+                throw new DecryptException(Exception::DECRYPT_WECHAT_ENCRYPTED_DATA_INVALID, '加解密异常: 待解密数据非正常数据');
+            }
+        }
+
+        return $decrypted;
+    }
+
+    /**
+     * @throws ContainerException
+     * @throws DecryptException
+     * @throws InvalidConfigException
+     * @throws InvalidParamsException
+     * @throws ServiceNotFoundException
+     */
+    public static function getWechatSerialNo(array $params): string
+    {
+        if (!empty($params['_serial_no'])) {
+            return $params['_serial_no'];
+        }
+
+        $config = self::getProviderConfig('wechat', $params);
+
+        if (empty($config['wechat_public_cert_path'])) {
+            self::reloadWechatPublicCerts($params);
+
+            $config = self::getProviderConfig('wechat', $params);
+        }
+
+        mt_srand();
+
+        return strval(array_rand($config['wechat_public_cert_path']));
+    }
+
+    /**
+     * @throws InvalidParamsException
+     */
+    public static function getWechatPublicKey(array $config, string $serialNo): string
+    {
+        $publicKey = $config['wechat_public_cert_path'][$serialNo] ?? null;
+
+        if (empty($publicKey)) {
+            throw new InvalidParamsException(Exception::PARAMS_WECHAT_SERIAL_NOT_FOUND, '参数异常: 微信公钥序列号未找到 - '.$serialNo);
+        }
+
+        return $publicKey;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public static function getWechatMiniprogramPaySign(array $config, string $url, string $payload): string
+    {
+        if (empty($config['mini_app_key_virtual_pay'])) {
+            throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 缺少微信配置 -- [mini_app_key_virtual_pay]');
+        }
+
+        return hash_hmac('sha256', $url.'&'.$payload, $config['mini_app_key_virtual_pay']);
+    }
+
+    public static function getWechatMiniprogramUserSign(string $sessionKey, string $payload): string
+    {
+        return hash_hmac('sha256', $payload, $sessionKey);
+    }
+}

--- a/tests/CertManagerTest.php
+++ b/tests/CertManagerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests;
+
+use PHPUnit\Framework\Assert;
+use Yansongda\Pay\CertManager;
+
+class CertManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CertManager::clearCache();
+    }
+
+    public function testGetPublicCertFromFile(): void
+    {
+        $path = __DIR__.'/Cert/alipayPublicCert.crt';
+
+        Assert::assertSame(file_get_contents($path), CertManager::getPublicCert($path));
+    }
+
+    public function testGetPublicCertFromString(): void
+    {
+        $content = file_get_contents(__DIR__.'/Cert/alipayPublicCert.crt');
+
+        Assert::assertSame($content, CertManager::getPublicCert($content));
+    }
+
+    public function testGetPublicCertCacheHit(): void
+    {
+        $source = __DIR__.'/Cert/alipayPublicCert.crt';
+        $path = sys_get_temp_dir().'/'.uniqid('cert-manager-public-', true).'.crt';
+
+        copy($source, $path);
+
+        try {
+            $first = CertManager::getPublicCert($path);
+            file_put_contents($path, 'changed-cert-content');
+
+            Assert::assertSame($first, CertManager::getPublicCert($path));
+        } finally {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    public function testGetPrivateCertFromFile(): void
+    {
+        $path = __DIR__.'/Cert/wechatAppPrivateKey.pem';
+
+        Assert::assertSame(file_get_contents($path), CertManager::getPrivateCert($path));
+    }
+
+    public function testGetPrivateCertFromString(): void
+    {
+        $key = file_get_contents(__DIR__.'/Cert/wechatAppPrivateKey.pem');
+        $key = preg_replace('/-----BEGIN PRIVATE KEY-----|-----END PRIVATE KEY-----|\s+/', '', $key);
+
+        $expected = "-----BEGIN RSA PRIVATE KEY-----\n"
+            .wordwrap($key, 64, "\n", true)
+            ."\n-----END RSA PRIVATE KEY-----";
+
+        Assert::assertSame($expected, CertManager::getPrivateCert($key));
+    }
+
+    public function testClearCache(): void
+    {
+        $path = __DIR__.'/Cert/alipayPublicCert.crt';
+
+        $first = CertManager::getPublicCert($path);
+        CertManager::clearCache();
+
+        Assert::assertSame($first, CertManager::getPublicCert($path));
+    }
+}

--- a/tests/Plugin/Stripe/V1/VerifyWebhookSignTest.php
+++ b/tests/Plugin/Stripe/V1/VerifyWebhookSignTest.php
@@ -9,8 +9,7 @@ use Yansongda\Artful\Exception\InvalidConfigException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Tests\TestCase;
-
-use function Yansongda\Pay\verify_stripe_webhook_sign;
+use Yansongda\Pay\Traits\StripeTrait;
 
 class VerifyWebhookSignTest extends TestCase
 {
@@ -18,11 +17,10 @@ class VerifyWebhookSignTest extends TestCase
     {
         $request = new ServerRequest('POST', 'http://localhost', [], '{}');
 
-        // localhost should no longer skip verification — missing Stripe-Signature should throw SIGN_EMPTY
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
     }
 
     public function testMissingWebhookSecretThrowsException()
@@ -32,7 +30,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidConfigException::class);
         self::expectExceptionCode(Exception::CONFIG_STRIPE_INVALID);
 
-        verify_stripe_webhook_sign($request, ['_config' => 'no_webhook_secret']);
+        StripeTrait::verifyStripeWebhookSign($request, ['_config' => 'no_webhook_secret']);
     }
 
     public function testEmptySignatureHeaderThrowsException()
@@ -42,7 +40,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
     }
 
     public function testMalformedSignatureHeaderThrowsException()
@@ -54,7 +52,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
     }
 
     public function testExpiredTimestampThrowsException()
@@ -69,7 +67,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
     }
 
     public function testWrongSignatureThrowsException()
@@ -84,7 +82,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
     }
 
     public function testValidSignaturePasses()
@@ -100,8 +98,7 @@ class VerifyWebhookSignTest extends TestCase
             'Stripe-Signature' => $signatureHeader,
         ], $body);
 
-        // Should not throw
-        verify_stripe_webhook_sign($request, []);
+        StripeTrait::verifyStripeWebhookSign($request, []);
 
         self::assertTrue(true);
     }

--- a/tests/Service/AbstractServiceProviderTest.php
+++ b/tests/Service/AbstractServiceProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Service;
+
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Service\AbstractServiceProvider;
+use Yansongda\Pay\Tests\TestCase;
+
+class AbstractServiceProviderTest extends TestCase
+{
+    public function testRegister(): void
+    {
+        $provider = new ConcreteServiceProvider();
+        $provider->register();
+
+        self::assertInstanceOf(ConcreteProvider::class, Pay::get(ConcreteProvider::class));
+        self::assertSame(Pay::get(ConcreteProvider::class), Pay::get('concrete_provider'));
+    }
+}
+
+class ConcreteServiceProvider extends AbstractServiceProvider
+{
+    protected function getProviderClass(): string
+    {
+        return ConcreteProvider::class;
+    }
+
+    protected function getProviderName(): string
+    {
+        return 'concrete_provider';
+    }
+}
+
+class ConcreteProvider
+{
+}

--- a/tests/Traits/AlipayTraitTest.php
+++ b/tests/Traits/AlipayTraitTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Tests\Traits;
 
-use Yansongda\Pay\Exception\Exception;
+use Yansongda\Artful\Contract\ConfigInterface;
 use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\AlipayTrait;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
 use Yansongda\Supports\Collection;
 
 class AlipayTraitStub
@@ -19,40 +21,48 @@ class AlipayTraitStub
 
 class AlipayTraitTest extends TestCase
 {
-    public function testVerifyAlipaySignEmptySign(): void
+    public function testVerifyAlipaySignSuccess(): void
+    {
+        ProviderConfigTrait::getProviderConfig('alipay');
+        
+        AlipayTraitStub::verifyAlipaySign(
+            ProviderConfigTrait::getProviderConfig('alipay'),
+            json_encode([
+                "code" => "10000",
+                "msg" => "Success",
+                "order_id" => "20231220110070000002150000657610",
+                "out_biz_no" => "2023122022560000",
+                "pay_date" => "2023-12-20 22:56:33",
+                "pay_fund_order_id" => "20231220110070001502150000660902",
+                "status" => "SUCCESS",
+                "trans_amount" => "0.01",
+            ], JSON_UNESCAPED_UNICODE),
+            'eITxP5fZiJPB2+vZb90IRkv2iARxeNx/6Omxk7FStqflhG5lMoCvGjo2FZ6Szo1bGBMBReazZuqLaqsgomWAUO9onMVurB3enLbRvwUlpE7XEZaxk/sJYjgc2Y7pIAenvnLL9PEAiXmvUvuinUlvS9J2r1XysC0p/2wu7kEJ/GgZpFDIIYY9mdM6U1rGbi+RvirQXtQHmaEuuJWLA75NR1bvfG3L8znzW9xz1kOQqOWsQmD/bF1CDWbozNLwLCUmClRJz0Fj4mUYRF0zbW2VP8ZgHu1YvVKJ2+dWC9b+0o94URk7psIpc5NjiOM9Jsn6aoC2CfrJ/sqFMRCkYWzw6A=='
+        );
+        self::assertTrue(true);
+    }
+
+    public function testVerifyAlipaySignConfigError(): void
+    {
+        $config1 = [
+            'alipay' => [
+                'default' => [
+                    'alipay_public_cert_path' => ''
+                ],
+            ]
+        ];
+        Pay::config(array_merge($config1, ['_force' => true]));
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
+        AlipayTraitStub::verifyAlipaySign(ProviderConfigTrait::getProviderConfig('alipay'), '', 'aaa');
+    }
+
+    public function testVerifyAlipaySignEmpty(): void
     {
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
-
-        AlipayTraitStub::verifyAlipaySign(['alipay_public_cert_path' => 'dummy'], 'contents', '');
-    }
-
-    public function testVerifyAlipaySignMissingCert(): void
-    {
-        self::expectException(InvalidConfigException::class);
-        self::expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
-
-        AlipayTraitStub::verifyAlipaySign([], 'contents', 'sign');
-    }
-
-    public function testVerifyAlipaySignSuccess(): void
-    {
-        $privateKey = openssl_pkey_new([
-            'private_key_bits' => 2048,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-
-        openssl_pkey_export($privateKey, $privatePem);
-        $publicKey = openssl_pkey_get_details($privateKey)['key'];
-
-        $contents = 'app_id=2021000000000000&method=alipay.test';
-        openssl_sign($contents, $signature, $privatePem, OPENSSL_ALGO_SHA256);
-
-        AlipayTraitStub::verifyAlipaySign([
-            'alipay_public_cert_path' => $publicKey,
-        ], $contents, base64_encode($signature));
-
-        self::assertTrue(true);
+        AlipayTraitStub::verifyAlipaySign(ProviderConfigTrait::getProviderConfig('alipay'), '', '');
     }
 
     public function testGetAlipayUrlDefault(): void

--- a/tests/Traits/AlipayTraitTest.php
+++ b/tests/Traits/AlipayTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\AlipayTrait;
+use Yansongda\Supports\Collection;
+
+class AlipayTraitStub
+{
+    use AlipayTrait;
+}
+
+class AlipayTraitTest extends TestCase
+{
+    public function testVerifyAlipaySignEmptySign(): void
+    {
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        AlipayTraitStub::verifyAlipaySign(['alipay_public_cert_path' => 'dummy'], 'contents', '');
+    }
+
+    public function testVerifyAlipaySignMissingCert(): void
+    {
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
+
+        AlipayTraitStub::verifyAlipaySign([], 'contents', 'sign');
+    }
+
+    public function testVerifyAlipaySignSuccess(): void
+    {
+        $privateKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        openssl_pkey_export($privateKey, $privatePem);
+        $publicKey = openssl_pkey_get_details($privateKey)['key'];
+
+        $contents = 'app_id=2021000000000000&method=alipay.test';
+        openssl_sign($contents, $signature, $privatePem, OPENSSL_ALGO_SHA256);
+
+        AlipayTraitStub::verifyAlipaySign([
+            'alipay_public_cert_path' => $publicKey,
+        ], $contents, base64_encode($signature));
+
+        self::assertTrue(true);
+    }
+
+    public function testGetAlipayUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Alipay::URL[Pay::MODE_NORMAL],
+            AlipayTraitStub::getAlipayUrl([], null)
+        );
+    }
+
+    public function testGetAlipayUrlSandbox(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Alipay::URL[Pay::MODE_SANDBOX],
+            AlipayTraitStub::getAlipayUrl(['mode' => Pay::MODE_SANDBOX], null)
+        );
+    }
+
+    public function testGetAlipayUrlWithPayload(): void
+    {
+        self::assertSame(
+            'https://example.com/alipay',
+            AlipayTraitStub::getAlipayUrl([], new Collection(['_url' => 'https://example.com/alipay']))
+        );
+    }
+}

--- a/tests/Traits/DouyinTraitTest.php
+++ b/tests/Traits/DouyinTraitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\DouyinTrait;
+use Yansongda\Supports\Collection;
+
+class DouyinTraitStub
+{
+    use DouyinTrait;
+}
+
+class DouyinTraitTest extends TestCase
+{
+    public function testGetDouyinUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Douyin::URL[Pay::MODE_NORMAL].'/mini',
+            DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => '/mini']))
+        );
+    }
+
+    public function testGetDouyinUrlWithHttp(): void
+    {
+        self::assertSame(
+            'https://example.com/douyin',
+            DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => 'https://example.com/douyin']))
+        );
+    }
+}

--- a/tests/Traits/DouyinTraitTest.php
+++ b/tests/Traits/DouyinTraitTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Tests\Traits;
 
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\DouyinTrait;
@@ -16,19 +18,15 @@ class DouyinTraitStub
 
 class DouyinTraitTest extends TestCase
 {
-    public function testGetDouyinUrlDefault(): void
+    public function testGetDouyinUrl(): void
     {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Douyin::URL[Pay::MODE_NORMAL].'/mini',
-            DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => '/mini']))
-        );
-    }
+        self::assertEquals('https://yansongda.cn', DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://developer.toutiao.com/api/v1/yansongda', DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => 'api/v1/yansongda'])));
+        self::assertEquals('https://developer.toutiao.com/api/v1/service/yansongda', DouyinTraitStub::getDouyinUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_service_url' => 'api/v1/service/yansongda'])));
+        self::assertEquals('https://developer.toutiao.com/api/v1/service/yansongda', DouyinTraitStub::getDouyinUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_url' => 'foo', '_service_url' => 'api/v1/service/yansongda'])));
 
-    public function testGetDouyinUrlWithHttp(): void
-    {
-        self::assertSame(
-            'https://example.com/douyin',
-            DouyinTraitStub::getDouyinUrl([], new Collection(['_url' => 'https://example.com/douyin']))
-        );
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_DOUYIN_URL_MISSING);
+        DouyinTraitStub::getDouyinUrl([], new Collection([]));
     }
 }

--- a/tests/Traits/JsbTraitTest.php
+++ b/tests/Traits/JsbTraitTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Yansongda\Pay\Tests\Traits;
 
 use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\JsbTrait;
@@ -18,25 +20,16 @@ class JsbTraitStub
 
 class JsbTraitTest extends TestCase
 {
-    public function testGetJsbUrlWithHttp(): void
+    public function testGetJsbUrl(): void
     {
-        self::assertSame(
-            'https://example.com/jsb',
-            JsbTraitStub::getJsbUrl([], new Collection(['_url' => 'https://example.com/jsb']))
-        );
-    }
-
-    public function testGetJsbUrlDefault(): void
-    {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Jsb::URL[Pay::MODE_NORMAL],
-            JsbTraitStub::getJsbUrl([], new Collection())
-        );
+        self::assertEquals('https://yansongda.cn', JsbTraitStub::getJsbUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://mybank.jsbchina.cn:577/eis/merchant/merchantServices.htm', JsbTraitStub::getJsbUrl(['mode' => Pay::MODE_NORMAL], new Collection()));
+        self::assertEquals('https://epaytest.jsbchina.cn:9999/eis/merchant/merchantServices.htm', JsbTraitStub::getJsbUrl(['mode' => Pay::MODE_SANDBOX], new Collection()));
     }
 
     public function testVerifyJsbSignEmpty(): void
     {
-        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
         JsbTraitStub::verifyJsbSign(['jsb_public_cert_path' => 'x'], 'content', '');

--- a/tests/Traits/JsbTraitTest.php
+++ b/tests/Traits/JsbTraitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\JsbTrait;
+use Yansongda\Supports\Collection;
+
+class JsbTraitStub
+{
+    use JsbTrait;
+}
+
+class JsbTraitTest extends TestCase
+{
+    public function testGetJsbUrlWithHttp(): void
+    {
+        self::assertSame(
+            'https://example.com/jsb',
+            JsbTraitStub::getJsbUrl([], new Collection(['_url' => 'https://example.com/jsb']))
+        );
+    }
+
+    public function testGetJsbUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Jsb::URL[Pay::MODE_NORMAL],
+            JsbTraitStub::getJsbUrl([], new Collection())
+        );
+    }
+
+    public function testVerifyJsbSignEmpty(): void
+    {
+        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        JsbTraitStub::verifyJsbSign(['jsb_public_cert_path' => 'x'], 'content', '');
+    }
+
+    public function testVerifyJsbSignMissingConfig(): void
+    {
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_JSB_INVALID);
+
+        JsbTraitStub::verifyJsbSign([], 'content', 'sign');
+    }
+}

--- a/tests/Traits/PaypalTraitTest.php
+++ b/tests/Traits/PaypalTraitTest.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Tests\Traits;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
+use Mockery;
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Contract\HttpClientInterface;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\PaypalTrait;
@@ -18,27 +26,139 @@ class PaypalTraitStub
 
 class PaypalTraitTest extends TestCase
 {
-    public function testGetPaypalUrlDefault(): void
+    public function testGetPaypalUrl(): void
     {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Paypal::URL[Pay::MODE_NORMAL].'/v2/checkout',
-            PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => '/v2/checkout']))
-        );
+        self::assertEquals('https://yansongda.cn', PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://api-m.paypal.com/v2/checkout/orders', PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => 'v2/checkout/orders'])));
+        self::assertEquals('https://api-m.sandbox.paypal.com/v2/checkout/orders', PaypalTraitStub::getPaypalUrl(['mode' => Pay::MODE_SANDBOX], new Collection(['_url' => 'v2/checkout/orders'])));
+
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_PAYPAL_URL_MISSING);
+        PaypalTraitStub::getPaypalUrl([], new Collection([]));
     }
 
-    public function testGetPaypalUrlWithHttp(): void
+    public function testGetPaypalAccessTokenCached(): void
     {
-        self::assertSame(
-            'https://example.com/paypal',
-            PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => 'https://example.com/paypal']))
-        );
+        Pay::get(ConfigInterface::class)->set('paypal.default._access_token', 'cached_token_123');
+        Pay::get(ConfigInterface::class)->set('paypal.default._access_token_expiry', time() + 3600);
+
+        $token = PaypalTraitStub::getPaypalAccessToken([]);
+
+        self::assertEquals('cached_token_123', $token);
     }
 
-    public function testVerifyPaypalWebhookSignMissingConfig(): void
+    public function testGetPaypalAccessTokenMissingConfig(): void
     {
-        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_PAYPAL_INVALID);
+
+        PaypalTraitStub::getPaypalAccessToken(['_config' => 'empty_paypal']);
+    }
+
+    public function testGetPaypalAccessTokenFresh(): void
+    {
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'access_token' => 'new_paypal_token_456',
+                'token_type' => 'Bearer',
+                'expires_in' => 32400,
+            ])
+        );
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($response);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $token = PaypalTraitStub::getPaypalAccessToken([]);
+
+        self::assertEquals('new_paypal_token_456', $token);
+        self::assertEquals('new_paypal_token_456', Pay::get(ConfigInterface::class)->get('paypal.default._access_token'));
+        self::assertNotEmpty(Pay::get(ConfigInterface::class)->get('paypal.default._access_token_expiry'));
+    }
+
+    public function testVerifyPaypalWebhookSignMissingWebhookId(): void
+    {
+        Pay::get(ConfigInterface::class)->set('paypal.default.webhook_id', '');
+
+        $request = new ServerRequest('POST', 'https://pay.yansongda.cn/paypal/notify', [
+            'PAYPAL-TRANSMISSION-ID' => 'test-id',
+            'PAYPAL-TRANSMISSION-SIG' => 'test-sig',
+        ], '{}');
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_PAYPAL_INVALID);
+
+        PaypalTraitStub::verifyPaypalWebhookSign($request, []);
+    }
+
+    public function testVerifyPaypalWebhookSignEmptySignature(): void
+    {
+        $request = new ServerRequest('POST', 'https://pay.yansongda.cn/paypal/notify', [], '{}');
+
+        self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        PaypalTraitStub::verifyPaypalWebhookSign(new ServerRequest('POST', 'https://example.com', [], '{}'), []);
+        PaypalTraitStub::verifyPaypalWebhookSign($request, []);
+    }
+
+    public function testVerifyPaypalWebhookSignSuccess(): void
+    {
+        $tokenResponse = new Response(200, [], json_encode([
+            'access_token' => 'verify_token_123',
+            'token_type' => 'Bearer',
+            'expires_in' => 32400,
+        ]));
+        $verifyResponse = new Response(200, [], json_encode([
+            'verification_status' => 'SUCCESS',
+        ]));
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($tokenResponse, $verifyResponse);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $request = new ServerRequest('POST', 'https://pay.yansongda.cn/paypal/notify', [
+            'PAYPAL-TRANSMISSION-ID' => 'test-id',
+            'PAYPAL-TRANSMISSION-TIME' => '2024-01-01T00:00:00Z',
+            'PAYPAL-TRANSMISSION-SIG' => 'test-sig',
+            'PAYPAL-CERT-URL' => 'https://api.sandbox.paypal.com/v1/notifications/certs/CERT-123',
+            'PAYPAL-AUTH-ALGO' => 'SHA256withRSA',
+        ], json_encode(['event_type' => 'CHECKOUT.ORDER.APPROVED']));
+
+        PaypalTraitStub::verifyPaypalWebhookSign($request, []);
+        self::assertTrue(true);
+    }
+
+    public function testVerifyPaypalWebhookSignFailure(): void
+    {
+        $tokenResponse = new Response(200, [], json_encode([
+            'access_token' => 'verify_token_123',
+            'token_type' => 'Bearer',
+            'expires_in' => 32400,
+        ]));
+        $verifyResponse = new Response(200, [], json_encode([
+            'verification_status' => 'FAILURE',
+        ]));
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($tokenResponse, $verifyResponse);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $request = new ServerRequest('POST', 'https://pay.yansongda.cn/paypal/notify', [
+            'PAYPAL-TRANSMISSION-ID' => 'test-id',
+            'PAYPAL-TRANSMISSION-TIME' => '2024-01-01T00:00:00Z',
+            'PAYPAL-TRANSMISSION-SIG' => 'test-sig',
+            'PAYPAL-CERT-URL' => 'https://api.sandbox.paypal.com/v1/notifications/certs/CERT-123',
+            'PAYPAL-AUTH-ALGO' => 'SHA256withRSA',
+        ], json_encode(['event_type' => 'CHECKOUT.ORDER.APPROVED']));
+
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_ERROR);
+
+        PaypalTraitStub::verifyPaypalWebhookSign($request, []);
     }
 }

--- a/tests/Traits/PaypalTraitTest.php
+++ b/tests/Traits/PaypalTraitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\PaypalTrait;
+use Yansongda\Supports\Collection;
+
+class PaypalTraitStub
+{
+    use PaypalTrait;
+}
+
+class PaypalTraitTest extends TestCase
+{
+    public function testGetPaypalUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Paypal::URL[Pay::MODE_NORMAL].'/v2/checkout',
+            PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => '/v2/checkout']))
+        );
+    }
+
+    public function testGetPaypalUrlWithHttp(): void
+    {
+        self::assertSame(
+            'https://example.com/paypal',
+            PaypalTraitStub::getPaypalUrl([], new Collection(['_url' => 'https://example.com/paypal']))
+        );
+    }
+
+    public function testVerifyPaypalWebhookSignMissingConfig(): void
+    {
+        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        PaypalTraitStub::verifyPaypalWebhookSign(new ServerRequest('POST', 'https://example.com', [], '{}'), []);
+    }
+}

--- a/tests/Traits/ProviderConfigTraitTest.php
+++ b/tests/Traits/ProviderConfigTraitTest.php
@@ -24,7 +24,7 @@ class ProviderConfigTraitTest extends TestCase
 
     public function testGetTenantCustom(): void
     {
-        self::assertSame('service_provider', ProviderConfigTraitStub::getTenant(['_config' => 'service_provider']));
+        self::assertSame('yansongda', ProviderConfigTraitStub::getTenant(['_config' => 'yansongda']));
     }
 
     public function testGetProviderConfigDefault(): void
@@ -35,12 +35,70 @@ class ProviderConfigTraitTest extends TestCase
         );
     }
 
+    public function testGetProviderConfigAlipay(): void
+    {
+        self::assertArrayHasKey('app_id', ProviderConfigTraitStub::getProviderConfig('alipay'));
+
+        PayFacade::clear();
+
+        $config2 = [
+            'alipay' => [
+                'default' => ['name' => 'yansongda'],
+                'c1' => ['age' => 28]
+            ]
+        ];
+        PayFacade::config($config2);
+        self::assertEquals(['name' => 'yansongda'], ProviderConfigTraitStub::getProviderConfig('alipay'));
+
+        self::assertEquals(['age' => 28], ProviderConfigTraitStub::getProviderConfig('alipay', ['_config' => 'c1']));
+    }
+
+    public function testGetProviderConfigWechat(): void
+    {
+        self::assertArrayHasKey('mp_app_id', ProviderConfigTraitStub::getProviderConfig('wechat', []));
+
+        $config2 = [
+            'wechat' => [
+                'default' => ['name' => 'yansongda'],
+                'c1' => ['age' => 28]
+            ]
+        ];
+        PayFacade::config(array_merge($config2, ['_force' => true]));
+        self::assertEquals(['name' => 'yansongda'], ProviderConfigTraitStub::getProviderConfig('wechat', []));
+
+        self::assertEquals(['age' => 28], ProviderConfigTraitStub::getProviderConfig('wechat', ['_config' => 'c1']));
+    }
+
+    public function testGetProviderConfigUnipay(): void
+    {
+        self::assertArrayHasKey('mch_id', ProviderConfigTraitStub::getProviderConfig('unipay'));
+
+        PayFacade::clear();
+
+        $config2 = [
+            'unipay' => [
+                'default' => ['name' => 'yansongda'],
+                'c1' => ['age' => 28]
+            ]
+        ];
+        PayFacade::config($config2);
+        self::assertEquals(['name' => 'yansongda'], ProviderConfigTraitStub::getProviderConfig('unipay'));
+
+        self::assertEquals(['age' => 28], ProviderConfigTraitStub::getProviderConfig('unipay', ['_config' => 'c1']));
+    }
+
     public function testGetProviderConfigCustomTenant(): void
     {
         self::assertSame(
             PayFacade::get(ConfigInterface::class)->get('wechat', [])['service_provider'] ?? [],
             ProviderConfigTraitStub::getProviderConfig('wechat', ['_config' => 'service_provider'])
         );
+    }
+
+    public function testGetRadarUrlNull(): void
+    {
+        self::assertNull(ProviderConfigTraitStub::getRadarUrl([], null));
+        self::assertNull(ProviderConfigTraitStub::getRadarUrl([], new Collection()));
     }
 
     public function testGetRadarUrlNormal(): void

--- a/tests/Traits/ProviderConfigTraitTest.php
+++ b/tests/Traits/ProviderConfigTraitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Pay\Pay as PayFacade;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
+use Yansongda\Supports\Collection;
+
+class ProviderConfigTraitStub
+{
+    use ProviderConfigTrait;
+}
+
+class ProviderConfigTraitTest extends TestCase
+{
+    public function testGetTenantDefault(): void
+    {
+        self::assertSame('default', ProviderConfigTraitStub::getTenant());
+    }
+
+    public function testGetTenantCustom(): void
+    {
+        self::assertSame('service_provider', ProviderConfigTraitStub::getTenant(['_config' => 'service_provider']));
+    }
+
+    public function testGetProviderConfigDefault(): void
+    {
+        self::assertSame(
+            PayFacade::get(ConfigInterface::class)->get('alipay', [])[ProviderConfigTraitStub::getTenant()] ?? [],
+            ProviderConfigTraitStub::getProviderConfig('alipay')
+        );
+    }
+
+    public function testGetProviderConfigCustomTenant(): void
+    {
+        self::assertSame(
+            PayFacade::get(ConfigInterface::class)->get('wechat', [])['service_provider'] ?? [],
+            ProviderConfigTraitStub::getProviderConfig('wechat', ['_config' => 'service_provider'])
+        );
+    }
+
+    public function testGetRadarUrlNormal(): void
+    {
+        self::assertSame(
+            'https://yansongda.cn',
+            ProviderConfigTraitStub::getRadarUrl([], new Collection(['_url' => 'https://yansongda.cn']))
+        );
+    }
+
+    public function testGetRadarUrlService(): void
+    {
+        self::assertSame(
+            'https://yansongda.cnaaa',
+            ProviderConfigTraitStub::getRadarUrl(
+                ['mode' => PayFacade::MODE_SERVICE],
+                new Collection(['_url' => 'https://yansongda.cn', '_service_url' => 'https://yansongda.cnaaa'])
+            )
+        );
+    }
+}

--- a/tests/Traits/StripeTraitTest.php
+++ b/tests/Traits/StripeTraitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\StripeTrait;
+use Yansongda\Supports\Collection;
+
+class StripeTraitStub
+{
+    use StripeTrait;
+}
+
+class StripeTraitTest extends TestCase
+{
+    public function testGetStripeUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Stripe::URL[Pay::MODE_NORMAL].'/v1/payment_intents',
+            StripeTraitStub::getStripeUrl([], new Collection(['_url' => '/v1/payment_intents']))
+        );
+    }
+
+    public function testGetStripeUrlWithHttp(): void
+    {
+        self::assertSame(
+            'https://example.com/stripe',
+            StripeTraitStub::getStripeUrl([], new Collection(['_url' => 'https://example.com/stripe']))
+        );
+    }
+
+    public function testVerifyStripeWebhookSignMissingConfig(): void
+    {
+        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        StripeTraitStub::verifyStripeWebhookSign(new ServerRequest('POST', 'https://example.com', [], '{}'), []);
+    }
+}

--- a/tests/Traits/StripeTraitTest.php
+++ b/tests/Traits/StripeTraitTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Yansongda\Pay\Tests\Traits;
 
 use GuzzleHttp\Psr7\ServerRequest;
+use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\StripeTrait;
@@ -18,27 +20,24 @@ class StripeTraitStub
 
 class StripeTraitTest extends TestCase
 {
-    public function testGetStripeUrlDefault(): void
+    public function testGetStripeUrl(): void
     {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Stripe::URL[Pay::MODE_NORMAL].'/v1/payment_intents',
-            StripeTraitStub::getStripeUrl([], new Collection(['_url' => '/v1/payment_intents']))
-        );
+        self::assertEquals('https://yansongda.cn', StripeTraitStub::getStripeUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://api.stripe.com/v1/payment_intents', StripeTraitStub::getStripeUrl([], new Collection(['_url' => 'v1/payment_intents'])));
+        self::assertEquals('https://api.stripe.com/v1/payment_intents', StripeTraitStub::getStripeUrl(['mode' => Pay::MODE_SANDBOX], new Collection(['_url' => 'v1/payment_intents'])));
+
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_STRIPE_URL_MISSING);
+        StripeTraitStub::getStripeUrl([], new Collection([]));
     }
 
-    public function testGetStripeUrlWithHttp(): void
+    public function testVerifyStripeWebhookSignEmptySignature(): void
     {
-        self::assertSame(
-            'https://example.com/stripe',
-            StripeTraitStub::getStripeUrl([], new Collection(['_url' => 'https://example.com/stripe']))
-        );
-    }
+        $request = new ServerRequest('POST', 'https://pay.yansongda.cn/stripe/notify', [], '{}');
 
-    public function testVerifyStripeWebhookSignMissingConfig(): void
-    {
-        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        StripeTraitStub::verifyStripeWebhookSign(new ServerRequest('POST', 'https://example.com', [], '{}'), []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 }

--- a/tests/Traits/UnipayTraitTest.php
+++ b/tests/Traits/UnipayTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\UnipayTrait;
+use Yansongda\Supports\Collection;
+
+class UnipayTraitStub
+{
+    use UnipayTrait;
+}
+
+class UnipayTraitTest extends TestCase
+{
+    public function testGetUnipayUrlDefault(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Unipay::URL[Pay::MODE_NORMAL].'/test',
+            UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => '/test']))
+        );
+    }
+
+    public function testGetUnipayUrlWithHttp(): void
+    {
+        self::assertSame(
+            'https://example.com/unipay',
+            UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => 'https://example.com/unipay']))
+        );
+    }
+
+    public function testVerifyUnipaySignEmpty(): void
+    {
+        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        UnipayTraitStub::verifyUnipaySign([], 'abc', '');
+    }
+
+    public function testVerifyUnipaySignMissingConfig(): void
+    {
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_UNIPAY_INVALID);
+
+        UnipayTraitStub::verifyUnipaySign([], 'abc', 'sign');
+    }
+
+    public function testGetUnipaySignQra(): void
+    {
+        self::assertSame(
+            strtoupper(md5('a=1&key=secret')),
+            UnipayTraitStub::getUnipaySignQra(['mch_secret_key' => 'secret'], ['a' => '1'])
+        );
+    }
+}

--- a/tests/Traits/UnipayTraitTest.php
+++ b/tests/Traits/UnipayTraitTest.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Tests\Traits;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Mockery;
+use Yansongda\Artful\Artful;
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Contract\HttpClientInterface;
 use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
 use Yansongda\Pay\Traits\UnipayTrait;
 use Yansongda\Supports\Collection;
 
@@ -18,43 +27,175 @@ class UnipayTraitStub
 
 class UnipayTraitTest extends TestCase
 {
-    public function testGetUnipayUrlDefault(): void
+    public function testVerifyUnipaySign(): void
     {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Unipay::URL[Pay::MODE_NORMAL].'/test',
-            UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => '/test']))
-        );
-    }
+        $contents = "accNo=ORRSXWY1kMr8UJNxGx9xKPuO0Uhm8JT8aQV3sWswJfIsj/grkjauH4soyAtiqB9XwQotZOwmUAs/pkMupUkfiX9npdFGGEUEc5gqq+lcEwyD7tLmd2WBzRvcEvvjAKMKwTCFDxmQbIrP48ocIVhPoZ87ZQtQM5MIyJYedrzPRlt6BzRddUPGU1gJwDA8APDx3iyNl8EAfenJw7DUDZimmhbE1VSRmQm/iqgJurI7juq/6ztDHZHv4ys1eN9JYkwhcKxCjsWpwXTSy0PGvDXhsAZsDuNXHsjI8JLhHXvTDaU2+gc289LZPiwpr4Ah/reIuPWrIHubchYm2XTqQlUAaw==&accessType=0&bizType=000201&currencyCode=156&encoding=utf-8&exchangeRate=0&merId=777290058167151&orderId=yansongda20220908132206&queryId=782209081322060674028&respCode=00&respMsg=success&settleAmt=1&settleCurrencyCode=156&settleDate=0908&signMethod=01&signPubKeyCert=-----BEGIN CERTIFICATE-----\r
+MIIEYzCCA0ugAwIBAgIFEDkwhTQwDQYJKoZIhvcNAQEFBQAwWDELMAkGA1UEBhMC\r
+Q04xMDAuBgNVBAoTJ0NoaW5hIEZpbmFuY2lhbCBDZXJ0aWZpY2F0aW9uIEF1dGhv\r
+cml0eTEXMBUGA1UEAxMOQ0ZDQSBURVNUIE9DQTEwHhcNMjAwNzMxMDExOTE2WhcN\r
+MjUwNzMxMDExOTE2WjCBljELMAkGA1UEBhMCY24xEjAQBgNVBAoTCUNGQ0EgT0NB\r
+MTEWMBQGA1UECxMNTG9jYWwgUkEgT0NBMTEUMBIGA1UECxMLRW50ZXJwcmlzZXMx\r
+RTBDBgNVBAMMPDA0MUA4MzEwMDAwMDAwMDgzMDQwQOS4reWbvemTtuiBlOiCoeS7\r
+veaciemZkOWFrOWPuEAwMDAxNjQ5NTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\r
+AQoCggEBAMHNa81t44KBfUWUgZhb1YTx3nO9DeagzBO5ZEE9UZkdK5+2IpuYi48w\r
+eYisCaLpLuhrwTced19w2UR5hVrc29aa2TxMvQH9s74bsAy7mqUJX+mPd6KThmCr\r
+t5LriSQ7rDlD0MALq3yimLvkEdwYJnvyzA6CpHntP728HIGTXZH6zOL0OAvTnP8u\r
+RCHZ8sXJPFUkZcbG3oVpdXQTJVlISZUUUhsfSsNdvRDrcKYY+bDWTMEcG8ZuMZzL\r
+g0N+/spSwB8eWz+4P87nGFVlBMviBmJJX8u05oOXPyIcZu+CWybFQVcS2sMWDVZy\r
+sPeT3tPuBDbFWmKQYuu+gT83PM3G6zMCAwEAAaOB9DCB8TAfBgNVHSMEGDAWgBTP\r
+cJ1h6518Lrj3ywJA9wmd/jN0gDBIBgNVHSAEQTA/MD0GCGCBHIbvKgEBMDEwLwYI\r
+KwYBBQUHAgEWI2h0dHA6Ly93d3cuY2ZjYS5jb20uY24vdXMvdXMtMTQuaHRtMDkG\r
+A1UdHwQyMDAwLqAsoCqGKGh0dHA6Ly91Y3JsLmNmY2EuY29tLmNuL1JTQS9jcmw3\r
+NTAwMy5jcmwwCwYDVR0PBAQDAgPoMB0GA1UdDgQWBBTmzk7XEM/J/sd+wPrMils3\r
+9rJ2/DAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwQwDQYJKoZIhvcNAQEF\r
+BQADggEBAJLbXxbJaFngROADdNmNUyVxPtbAvK32Ia0EjgDh/vjn1hpRNgvL4flH\r
+NsGNttCy8afLJcH8UnFJyGLas8v/P3UKXTJtgrOj1mtothv7CQa4LUYhzrVw3UhL\r
+4L1CTtmE6D1Kf3+c2Fj6TneK+MoK9AuckySjK5at6a2GQi18Y27gVF88Nk8bp1lJ\r
+vzOwPKd8R7iGFotuF4/8GGhBKR4k46EYnKCodyIhNpPdQfpaN5AKeS7xeLSbFvPJ\r
+HYrtBsI48jUK/WKtWBJWhFH+Gty+GWX0e5n2QHXHW6qH62M0lDo7OYeyBvG1mh9u\r
+Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
+-----END CERTIFICATE-----&traceNo=067402&traceTime=0908132206&txnAmt=1&txnSubType=01&txnTime=20220908132206&txnType=01&version=5.1.0";
+        $sign = 'JeA4S2+6TbGo9yjXDUvV5A2E3oJbunoCcZ66exN6xR3OH/5PNDK1VSV1Mq7XhVdxzkTeREUveiOYHalqoagRkh71nsHVvruwGbk6azygXSaawuO5tF67UIqNd4Mbufwh1KhbVpEkKbOETUvRhFcdon0fulE97I83eMSk52INHt8E1xk8NdbhyUadSlp+Uv30AKx70PpQbTGmVS3PJfd+Whj0b7LnvZKeC+BS1kUOtIKlcZO+gBoTigvCIJqj51kBrcBCs+x+VaeGm7EYBBhGSERpfQhQ4n+eJBwLdBeZ0/dNbo3iELjvVMx0n9KoW4klvUJhaH5LALA8pV02SbZv4Q==';
 
-    public function testGetUnipayUrlWithHttp(): void
-    {
-        self::assertSame(
-            'https://example.com/unipay',
-            UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => 'https://example.com/unipay']))
-        );
+        UnipayTraitStub::verifyUnipaySign(ProviderConfigTrait::getProviderConfig('unipay'), $contents, $sign);
+
+        self::assertTrue(true);
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_UNIPAY_INVALID);
+        self::expectExceptionMessage('配置异常： 缺少银联配置 -- [unipay_public_cert_path]');
+        Artful::get(ConfigInterface::class)->set('unipay.default.unipay_public_cert_path', null);
+        UnipayTraitStub::verifyUnipaySign([], $contents, $sign);
     }
 
     public function testVerifyUnipaySignEmpty(): void
     {
-        self::expectException(\Yansongda\Pay\Exception\InvalidSignException::class);
+        self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
-
-        UnipayTraitStub::verifyUnipaySign([], 'abc', '');
+        self::expectExceptionMessage('签名异常: 银联签名为空');
+        UnipayTraitStub::verifyUnipaySign([], '', '');
     }
 
-    public function testVerifyUnipaySignMissingConfig(): void
+    public function testGetUnipayUrl(): void
     {
-        self::expectException(InvalidConfigException::class);
-        self::expectExceptionCode(Exception::CONFIG_UNIPAY_INVALID);
+        self::assertEquals('https://yansongda.cn', UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://gateway.95516.com/api/v1/yansongda', UnipayTraitStub::getUnipayUrl([], new Collection(['_url' => 'api/v1/yansongda'])));
+        self::assertEquals('https://gateway.95516.com/api/v1/service/yansongda', UnipayTraitStub::getUnipayUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_service_url' => 'api/v1/service/yansongda'])));
+        self::assertEquals('https://gateway.95516.com/api/v1/service/yansongda', UnipayTraitStub::getUnipayUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_url' => 'foo', '_service_url' => 'api/v1/service/yansongda'])));
 
-        UnipayTraitStub::verifyUnipaySign([], 'abc', 'sign');
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_UNIPAY_URL_MISSING);
+        UnipayTraitStub::getUnipayUrl([], new Collection([]));
+    }
+
+    public function testGetUnipayBody(): void
+    {
+        self::assertEquals('https://yansongda.cn', UnipayTraitStub::getUnipayBody(new Collection(['_body' => 'https://yansongda.cn'])));
+
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_UNIPAY_BODY_MISSING);
+        UnipayTraitStub::getUnipayBody(new Collection([]));
     }
 
     public function testGetUnipaySignQra(): void
     {
-        self::assertSame(
-            strtoupper(md5('a=1&key=secret')),
-            UnipayTraitStub::getUnipaySignQra(['mch_secret_key' => 'secret'], ['a' => '1'])
-        );
+        $config = ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']);
+
+        $payload = [
+            'out_trade_no' => 'pos-qra-20240106163401',
+            'body' => '测试商品',
+            'total_fee' => 1,
+            'mch_create_ip' => '127.0.0.1',
+            'auth_code' => '131969896307360385',
+            'op_device_id' => '123',
+            'terminal_info' => json_encode([
+                'device_type' => '07',
+                'terminal_id' => '123',
+            ]),
+            'service' => 'unified.trade.micropay',
+            'charset' => 'UTF-8',
+            'sign_type' => 'MD5',
+            'mch_id' => 'QRA29045311KKR1',
+            'nonce_str' => 'UhxOr4kzerPGku9wCaVQyfd1zisoAnAm',
+        ];
+
+        self::assertEquals('DB571C2F75C657B42485CD07470F0FB9', UnipayTraitStub::getUnipaySignQra($config, $payload));
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_UNIPAY_INVALID);
+        UnipayTraitStub::getUnipaySignQra([], $payload);
+    }
+
+    public function testVerifyUnipaySignQra(): void
+    {
+        $payload = [
+            "charset" => "UTF-8",
+            "code" => "9999999",
+            "err_code" => "NOAUTH",
+            "err_msg" => "此商家涉嫌违规，收款功能已被限制，暂无法支付。商家可以登录微信商户平台/微信支付商家助手小程序查看原因和解决方案。",
+            "mch_id" => "QRA29045311KKR1",
+            "need_query" => "N",
+            "nonce_str" => "UhxOr4kzerPGku9wCaVQyfd1zisoAnAm",
+            "result_code" => "1",
+            "sign" => "4B9B2AA73A05CBC32CFDCB4456E12EBA",
+            "sign_type" => "MD5",
+            "status" => "0",
+            "transaction_id" => "95516000379952690603566602920171",
+            "version" => "2.0",
+        ];
+
+        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
+        self::assertTrue(true);
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_UNIPAY_INVALID);
+        UnipayTraitStub::getUnipaySignQra([], $payload);
+    }
+
+    public function testVerifyUnipaySignQraWrong(): void
+    {
+        $payload = [
+            "charset" => "UTF-8",
+            "code" => "9999999",
+            "err_code" => "NOAUTH",
+            "err_msg" => "此商家涉嫌违规，收款功能已被限制，暂无法支付。商家可以登录微信商户平台/微信支付商家助手小程序查看原因和解决方案。",
+            "mch_id" => "QRA29045311KKR1",
+            "need_query" => "N",
+            "nonce_str" => "UhxOr4kzerPGku9wCaVQyfd1zisoAnAm",
+            "result_code" => "1",
+            "sign" => "4B9B2AA73A05CBC32CFDCB4456E12EB1",
+            "sign_type" => "MD5",
+            "status" => "0",
+            "transaction_id" => "95516000379952690603566602920171",
+            "version" => "2.0",
+        ];
+
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_ERROR);
+
+        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
+    }
+
+    public function testVerifyUnipaySignQraEmpty(): void
+    {
+        $payload = [
+            "charset" => "UTF-8",
+            "code" => "9999999",
+            "err_code" => "NOAUTH",
+            "err_msg" => "此商家涉嫌违规，收款功能已被限制，暂无法支付。商家可以登录微信商户平台/微信支付商家助手小程序查看原因和解决方案。",
+            "mch_id" => "QRA29045311KKR1",
+            "need_query" => "N",
+            "nonce_str" => "UhxOr4kzerPGku9wCaVQyfd1zisoAnAm",
+            "result_code" => "1",
+            "sign_type" => "MD5",
+            "status" => "0",
+            "transaction_id" => "95516000379952690603566602920171",
+            "version" => "2.0",
+        ];
+
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+
+        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
     }
 }

--- a/tests/Traits/WechatTraitTest.php
+++ b/tests/Traits/WechatTraitTest.php
@@ -4,9 +4,21 @@ declare(strict_types=1);
 
 namespace Yansongda\Pay\Tests\Traits;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
+use Mockery;
+use Yansongda\Artful\Artful;
+use Yansongda\Artful\Contract\ConfigInterface;
+use Yansongda\Artful\Contract\HttpClientInterface;
+use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\Exception\DecryptException;
+use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\ProviderConfigTrait;
 use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
@@ -17,38 +29,346 @@ class WechatTraitStub
 
 class WechatTraitTest extends TestCase
 {
-    public function testGetWechatUrlRelativePath(): void
+    public function testGetWechatUrl(): void
     {
-        self::assertSame(
-            \Yansongda\Pay\Provider\Wechat::URL[Pay::MODE_NORMAL].'v3/pay/transactions/jsapi',
-            WechatTraitStub::getWechatUrl([], new Collection(['_url' => 'v3/pay/transactions/jsapi']))
+        self::assertEquals('https://yansongda.cn', WechatTraitStub::getWechatUrl([], new Collection(['_url' => 'https://yansongda.cn'])));
+        self::assertEquals('https://api.mch.weixin.qq.com/api/v1/yansongda', WechatTraitStub::getWechatUrl([], new Collection(['_url' => 'api/v1/yansongda'])));
+        self::assertEquals('https://api.mch.weixin.qq.com/api/v1/service/yansongda', WechatTraitStub::getWechatUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_service_url' => 'api/v1/service/yansongda'])));
+        self::assertEquals('https://api.mch.weixin.qq.com/api/v1/service/yansongda', WechatTraitStub::getWechatUrl(['mode' => Pay::MODE_SERVICE], new Collection(['_url' => 'foo', '_service_url' => 'api/v1/service/yansongda'])));
+
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_WECHAT_URL_MISSING);
+        WechatTraitStub::getWechatUrl([], new Collection([]));
+    }
+
+    public function testGetWechatMethod(): void
+    {
+        self::assertEquals('POST', WechatTraitStub::getWechatMethod(null));
+        self::assertEquals('GET', WechatTraitStub::getWechatMethod(new Collection(['_method' => 'get'])));
+        self::assertEquals('POST', WechatTraitStub::getWechatMethod(new Collection(['_method' => 'post'])));
+    }
+
+    public function testGetWechatBody(): void
+    {
+        self::assertEquals('https://yansongda.cn', WechatTraitStub::getWechatBody(new Collection(['_body' => 'https://yansongda.cn'])));
+
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_WECHAT_BODY_MISSING);
+        WechatTraitStub::getWechatBody(new Collection([]));
+    }
+
+    public function testGetWechatTypeKey(): void
+    {
+        // default
+        self::assertEquals('mp_app_id', WechatTraitStub::getWechatTypeKey([]));
+        // app
+        self::assertEquals('app_id', WechatTraitStub::getWechatTypeKey(['_type' => 'app']));
+        // mini
+        self::assertEquals('mini_app_id', WechatTraitStub::getWechatTypeKey(['_type' => 'mini']));
+    }
+
+    public function testGetWechatSign(): void
+    {
+        $contents = "POST\n/v3/pay/transactions/h5\n1626493236\nQqtzdVzxavZeXag9G5mtfzbfzFMf89p6\n{\"out_trade_no\":1626493236,\"description\":\"yansongda 测试 - 1626493236\",\"amount\":{\"total\":1},\"scene_info\":{\"payer_client_ip\":\"127.0.0.1\",\"h5_info\":{\"type\":\"Wap\"}},\"appid\":\"wx55955316af4ef13\",\"mchid\":\"1600314069\",\"notify_url\":\"http:\/\/127.0.0.1:8000\/wechat\/notify\"}\n";
+
+        self::assertEquals(
+            'KzIgMgiop3nQJNdBVR2Xah/JUwVBLDFFajyXPiSN8b8YAYEA4FuWfaCgFJ52+WFed+PhOYWx/ZPih4RaEuuSdYB8eZwYUx7RZGMQZk0bKCctAjjPuf4pJN+f/WsXKjPIy3diqF5x7gyxwSCaKWP4/KjsHNqgQpiC8q1uC5xmElzuhzSwj88LIoLtkAuSmtUVvdAt0Nz41ECHZgHWSGR32TfBo902r8afdaVKkFde8IoqcEJJcp6sMxdDO5l9R5KEWxrJ1SjsXVrb0IPH8Nj7e6hfhq7pucxojPpzsC+ZWAYvufZkAQx3kTiFmY87T+QhkP9FesOfWvkIRL4E6MP6ug==',
+            WechatTraitStub::getWechatSign(ProviderConfigTrait::getProviderConfig('wechat', []), $contents)
         );
+
+        // test config error
+        $config1 = [
+            'wechat' => [
+                'default' => [
+                    'mch_secret_cert' => ''
+                ],
+            ]
+        ];
+        Pay::config(array_merge($config1, ['_force' => true]));
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
+        WechatTraitStub::getWechatSign([], '', '');
     }
 
-    public function testGetWechatMethodDefault(): void
+    public function testGetWechatSignV2(): void
     {
-        self::assertSame('POST', WechatTraitStub::getWechatMethod(null));
+        $params = ['name' => 'yansongda', 'age' => 29, 'foo' => ''];
+        self::assertEquals('3213848AED2C380749FD1D559555881D', WechatTraitStub::getWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat', $params), $params));
+
+        // test config error
+        $config1 = [
+            'wechat' => [
+                'default' => [
+                    'mch_secret_key_v2' => ''
+                ],
+            ]
+        ];
+        Pay::config(array_merge($config1, ['_force' => true]));
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
+        WechatTraitStub::getWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), []);
     }
 
-    public function testVerifyWechatSignSuccess(): void
+    public function testVerifyWechatSign(): void
     {
-        $timestamp = '1700000000';
-        $nonce = 'nonce123';
-        $body = '{"id":"test"}';
-        $content = $timestamp."\n".$nonce."\n".$body."\n";
-
-        $privateKey = openssl_pkey_get_private(file_get_contents(dirname(__DIR__).'/Cert/wechatAppPrivateKey.pem'));
-        openssl_sign($content, $signature, $privateKey, 'sha256WithRSAEncryption');
-
-        $request = (new ServerRequest('POST', 'https://example.com/wechat'))
-            ->withHeader('Wechatpay-Serial', '45F59D4DABF31918AFCEC556D5D2C6E376675D57')
-            ->withHeader('Wechatpay-Timestamp', $timestamp)
-            ->withHeader('Wechatpay-Nonce', $nonce)
-            ->withHeader('Wechatpay-Signature', base64_encode($signature))
-            ->withBody(\GuzzleHttp\Psr7\Utils::streamFor($body));
-
-        WechatTraitStub::verifyWechatSign($request, []);
-
+        $response = new Response(
+            200,
+            [
+                'Wechatpay-Nonce' => 'e59e78a6c3f7dfd7e84aabee71be0452',
+                'Wechatpay-Signature' => 'Ut3dG8cMx5W1lbSQhHay068F6khScuPQJM/Z9+suaaSkbYUspFRlkdp2VR/6w5UMvioN0EveSgfypQFVqmT6tI//cWrA1J9rlnKmZ+FgdCMqg7FQnpMRzc1Ap+3mZMtN9GrzYqp/UdgotX6HRfGL3hP8pG1YuijHNrL0QRS17bNYwZX8Mj3qLKUQRpqbfE+TC5yvzh1gEVPBFTwvZdZvXIQpjC/sB2QDSvo72CWgm4huh1h/kMzsrsO+wXXLqDfU01YX8aLbBrjvpcob50lc5XZ2WX5nBbpJXaRatIhBUmkR/ccrQhxWN7YqEobBGK/2DYhr6e6CvTgVdpZUUEcMFw==',
+                'Wechatpay-Timestamp' => '1626444144',
+                'Wechatpay-Serial' => '45F59D4DABF31918AFCEC556D5D2C6E376675D57',
+            ],
+            json_encode(['h5_url' => 'https://wx.tenpay.com/cgi-bin/mmpayweb-bin/checkmweb?prepay_id=wx16220223998099f898c5b24eed5c320000&package=4049184564'], JSON_UNESCAPED_SLASHES),
+        );
+        WechatTraitStub::verifyWechatSign($response, []);
         self::assertTrue(true);
+
+        $response = new Response(
+            200,
+            [
+                'Wechatpay-Nonce' => 'e59e78a6c3f7dfd7e84aabee71be0452',
+                'Wechatpay-Signature' => 'Ut3dG8cMx5W1lbSQhHay068F6khScuPQJM/Z9+suaaSkbYUspFRlkdp2VR/6w5UMvioN0EveSgfypQFVqmT6tI//cWrA1J9rlnKmZ+FgdCMqg7FQnpMRzc1Ap+3mZMtN9GrzYqp/UdgotX6HRfGL3hP8pG1YuijHNrL0QRS17bNYwZX8Mj3qLKUQRpqbfE+TC5yvzh1gEVPBFTwvZdZvXIQpjC/sB2QDSvo72CWgm4huh1h/kMzsrsO+wXXLqDfU01YX8aLbBrjvpcob50lc5XZ2WX5nBbpJXaRatIhBUmkR/ccrQhxWN7YqEobBGK/2DYhr6e6CvTgVdpZUUEcMFw==',
+                'Wechatpay-Timestamp' => '1626444144',
+                'Wechatpay-Serial' => '45F59D4DABF31918AFCEC556D5D2C6E376675D57',
+            ],
+            json_encode(['h5_url' => 'https://wx.tenpay.com/cgi-bin/mmpayweb-bin/checkmweb?prepay_id=wx16220223998099f898c5b24eed5c320000&package=4049184564'], JSON_UNESCAPED_SLASHES),
+        );
+        $response->getBody()->read(10);
+        WechatTraitStub::verifyWechatSign($response, []);
+        self::assertTrue(true);
+    }
+
+    public function testVerifyWechatSignV2(): void
+    {
+        $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => '', 'sign' => '3213848AED2C380749FD1D559555881D'];
+        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+        self::assertTrue(true);
+
+        $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => ''];
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_EMPTY);
+        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+    }
+
+    public function testVerifyWechatSignV2EmptySecret(): void
+    {
+        $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => '', 'sign' => 'aaa'];
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
+
+        WechatTraitStub::verifyWechatSignV2([], $destination);
+    }
+
+    public function testVerifyWechatSignV2Wrong(): void
+    {
+        $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => '', 'sign' => 'foo'];
+
+        self::expectException(InvalidSignException::class);
+        self::expectExceptionCode(Exception::SIGN_ERROR);
+
+        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+    }
+
+    public function testEncryptWechatContents(): void
+    {
+        $serialNo = '45F59D4DABF31918AFCEC556D5D2C6E376675D57';
+        $contents = 'yansongda';
+        $result = WechatTraitStub::encryptWechatContents($contents, ProviderConfigTrait::getProviderConfig('wechat')['wechat_public_cert_path'][$serialNo]);
+        self::assertIsString($result);
+    }
+
+    public function testDecryptWechatContents(): void
+    {
+        $encrypted = 'WIesmK+dSJycwdhTTkNmv0Lk2wb9o7NGODovccjhyotNnRkEeh+sxRK1gNSRNMJJgkQ30m4HwcuweSO24mehFeXVNTVAKFVef/3FlHnYDZfE1c3mCLToEef7e8J/Z8TwFH1ecn3t+Jk9ZaBpQKNHdQ0Q8jcL7AnL48h0D9BcZxDekPqX6hNnKfISoKSv4TXFcgvBLFeAe4Q3KM0Snq0N5IvI86D9xZqVg6mY+Gfz0782ymQFxflau6Qxx3mJ+0etHMocNuCdgctVH390XYYMc0u+V2FCJ5cU5h/M/AxzP9ayrEO4l0ftaxL6lP0HjifNrkPcAAb+q9I67UepKO9iGw==';
+
+        $config = ProviderConfigTrait::getProviderConfig('wechat');
+
+        self::assertEquals('yansongda', WechatTraitStub::decryptWechatContents($encrypted, $config));
+        self::assertNull(WechatTraitStub::decryptWechatContents('invalid', $config));
+    }
+
+    public function testReloadWechatPublicCerts(): void
+    {
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'data' => [
+                    [
+                        'effective_time' => '2021-07-16T17:51:10+08:00',
+                        'encrypt_certificate' => [
+                            'algorithm' => 'AEAD_AES_256_GCM',
+                            'associated_data' => 'certificate',
+                            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+                            'nonce' => '4196a5b75276',
+                        ],
+                        'expire_time' => '2026-07-15T17:51:10+08:00',
+                        'serial_no' => 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57',
+                    ]
+                ]
+            ])
+        );
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($response);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $result = WechatTraitStub::reloadWechatPublicCerts([], 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57');
+
+        self::assertTrue(str_contains($result, '-----BEGIN CERTIFICATE-----'));
+        self::assertTrue(Artful::get(ConfigInterface::class)->has('wechat.default.wechat_public_cert_path.test-45F59D4DABF31918AFCEC556D5D2C6E376675D57'));
+        self::assertIsArray(Artful::get(ConfigInterface::class)->get('wechat.default'));
+    }
+
+    public function testGetWechatPublicCerts(): void
+    {
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'data' => [
+                    [
+                        'effective_time' => '2021-07-16T17:51:10+08:00',
+                        'encrypt_certificate' => [
+                            'algorithm' => 'AEAD_AES_256_GCM',
+                            'associated_data' => 'certificate',
+                            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+                            'nonce' => '4196a5b75276',
+                        ],
+                        'expire_time' => '2026-07-15T17:51:10+08:00',
+                        'serial_no' => 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57',
+                    ]
+                ]
+            ])
+        );
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($response);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $path = sys_get_temp_dir();
+
+        WechatTraitStub::getWechatPublicCerts([], $path);
+
+        $crtPathName = $path . '/test-45F59D4DABF31918AFCEC556D5D2C6E376675D57.crt';
+
+        self::assertFileExists($crtPathName);
+        self::assertTrue(str_contains(file_get_contents($crtPathName), '-----BEGIN CERTIFICATE-----'));
+
+        self::expectOutputRegex('/.*-----BEGIN CERTIFICATE-----/');
+        WechatTraitStub::getWechatPublicCerts();
+    }
+
+    public function testDecryptWechatResource(): void
+    {
+        $resource = [
+            'algorithm' => 'AEAD_AES_256_GCM',
+            'associated_data' => 'certificate',
+            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+            'nonce' => '4196a5b75276',
+        ];
+
+        $result = WechatTraitStub::decryptWechatResource($resource, ProviderConfigTrait::getProviderConfig('wechat'));
+
+        self::assertTrue(false !== strpos($result['ciphertext'], '-----BEGIN CERTIFICATE-----'));
+    }
+
+    public function testDecryptWechatResourceAes256Gcm(): void
+    {
+        $resource = [
+            'algorithm' => 'AEAD_AES_256_GCM',
+            'associated_data' => 'certificate',
+            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+            'nonce' => '4196a5b75276',
+        ];
+        $result = WechatTraitStub::decryptWechatResourceAes256Gcm(base64_decode($resource['ciphertext']), '53D67FCB97E68F9998CBD17ED7A8D1E2', $resource['nonce'], $resource['associated_data']);
+        self::assertTrue(false !== strpos($result, '-----BEGIN CERTIFICATE-----'));
+
+        $resource = [
+            'algorithm' => 'AEAD_AES_256_GCM',
+            'associated_data' => 'certificatea',
+            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+            'nonce' => '4196a5b75276',
+        ];
+        self::expectException(DecryptException::class);
+        self::expectExceptionCode(Exception::DECRYPT_WECHAT_ENCRYPTED_DATA_INVALID);
+        WechatTraitStub::decryptWechatResourceAes256Gcm(base64_decode($resource['ciphertext']), 'foo', $resource['nonce'], $resource['associated_data']);
+    }
+
+    public function testGetWechatSerialNo(): void
+    {
+        // 不传证书
+        $params = [];
+        $result = WechatTraitStub::getWechatSerialNo($params);
+        self::assertTrue(in_array($result, ['45F59D4DABF31918AFCEC556D5D2C6E376675D57', 'yansongda']));
+
+        // 传证书
+        $params = ['_serial_no' => 'yansongda',];
+        $result = WechatTraitStub::getWechatSerialNo($params);
+        self::assertEquals('yansongda', $result);
+    }
+
+    public function testGetWechatSerialNoWithRequestWechat(): void
+    {
+        $response = new Response(
+            200,
+            [],
+            json_encode([
+                'data' => [
+                    [
+                        'effective_time' => '2021-07-16T17:51:10+08:00',
+                        'encrypt_certificate' => [
+                            'algorithm' => 'AEAD_AES_256_GCM',
+                            'associated_data' => 'certificate',
+                            'ciphertext' => 'kbbHAUhBwdjYZkHPW149MW/8WNpxQo1Gyp4kVNVjd+zrXnyOFhgZic2U2+tobFAgfdr93zr0JZF3FdbxgkaOAV2NAeCfU8jsUYXSfn7fM8487jXMVXKKEneGiiv1/bDLkz7KFsTfu2y5Rv+igWQ+bvCUQAwoNzjupTXnnDR5hBiofZcFLHL45govyYE2o0qD5SLiJHcFS4pg/IOx8SIqUFNepr3piKXUxKowU8/kNxXyRzL8yp7XnhrzAzclupvjveNwZyiw3TqlLZdR5TbEFLCogWaRHZRqz3vKEfgRaUYUtXCtQVrm+adbSDBFIq34v+XfeIHMz9pKhH/m80N5Hx69hPzbvIdBhzwaEDyN3h8gaeYKFyW9xIAs5jCrzzUEkKyMzOKzx7XA+1HRakSyvs6RlkRTa/ztBy6aZL0nxK6XMZ9tA7zdf2VnBX/7WPQYRzoky0cVyH1KRZxI7In2hfvpjSvl6P7Adzp+EZXYM/dINTrrg+RQRe60tPy7vgE8PZZf+SAWzSZPWIm7Lx6GksJX0vnT4gOeTAPw6EeFsYU/ZD7fYslJOEbA14yHBrJFkwDpSI8aSHp2nZYbruM0y8IKr0p3vjN80Ko3jiRPxj4uNdJliR9WDCV22b9JeadAaJhO9+oSNbbtFnFTCZjXbf8rMz5KCGVrGRvUyB70zhRxYIOdTYKAEkmbU7jcMLd0aufuQqIw0WviQHB+ztrkjBCFwPu5/hlRVj9opNFnzYNltfVGrA1XW3NQ4FaMNah95ahomAG/+S7zJqq4Gvk1O/PgQ9kMP0adY3GlrHUNqr2zC709IervMQ1pEdcuNEln3V5TSDiE0x7BjoMoN2m+MKAIhw59VxzHGNmJELbkKsZUhKKXFFyEXFsw143/9IYOyanmHQxujdIBKI0rxYkVz9QgaajisCzdnRf0ymnkceGGnYsP7VTYBnuCncjgHxbEn3emlTRygEjgj/epupsQL2tfW+snxnafEM+Pc079pUYmKeCUEUoX/FUmdFIf8hlSHBTjEVMGsNUI/u2W781RBDfk2X/2QQQm3NOjgZ3le6hxEQqc12yANTvdq7cFVllWqMHBsXPCjpHWIHcS5BMkImoD7s6WItq60yJA8ioGJf3Rba+Yb/YeBBNxjDnXtAmX/2hJIsxEFLTYGUvdmFC5jeb5ifrOuxnLciKM8y4nLZ28dDsvVsaBBAMAFYfWb5NymKUDhhngR5bDuW4sKccZ6DmYQeStHT1fn2yoSneGA70HctQSWZ2roTdNihPTCs7rYD0dFeQ+SfLOJzMN4c5GbJ6n5tdCjERcLGIaXEKacfySo7e4VZtHeHowvlvBclS9pooZqzHd+EFlJEYywEs9jURgsJY2yHJt2zTZeIdsvM8KK5v0NkH8FiPbWqFG8LaRmUrqhJGLuLLRTcJnt6YVYESxUVTb3pmriUbXfg/ThHF/y0THyrM6bVDNOwNWZOpMYPPNaVmOTX39JdYayWl2HX0n8AsIRmevXzD4N9iDh2HGwie4gh92Qdcogwua++uhkhSsLFuWBpJiaPdxVtzz3E3jHfy+yryfh6msaXc/jmhwqBm/ii3j76lDP5YaRv4+JWZmom72+pmZuKD8qPKrPRxI2/aGiKEqgs25knpLLnbAhWAEYeIzVK1sQkjc5JFss1Std8FdDrHeM6agAB+MWncK1LloXZmiwz/6WmlwSDepnGHqLEciXThAZq6FwunJZTcHY9LamJgIY81c9t/KHlSFqlc/9mW4OZHM4BOZQ5sTj5PWE+OP2Aq9CKdJqoK3OmphBg2ewjrZt5/tSn9jpk6NlVrHD7MsJcKi5a0he4qvNPh1cHqUqWcF4rBFmfPptdHIBV77LXnizJZMUAwf16KsmJpwJg==',
+                            'nonce' => '4196a5b75276',
+                        ],
+                        'expire_time' => '2026-07-15T17:51:10+08:00',
+                        'serial_no' => 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57',
+                    ]
+                ]
+            ])
+        );
+
+        $http = Mockery::mock(Client::class);
+        $http->shouldReceive('sendRequest')->andReturn($response);
+
+        Pay::set(HttpClientInterface::class, $http);
+
+        $params = ['_config' => 'empty_wechat_public_cert'];
+        $result = WechatTraitStub::getWechatSerialNo($params);
+        self::assertEquals('test-45F59D4DABF31918AFCEC556D5D2C6E376675D57', $result);
+    }
+
+    public function testGetWechatPublicKey(): void
+    {
+        $serialNo = '45F59D4DABF31918AFCEC556D5D2C6E376675D57';
+        $result = WechatTraitStub::getWechatPublicKey(ProviderConfigTrait::getProviderConfig('wechat'), $serialNo);
+        self::assertIsString($result);
+
+        $serialNo = 'non-exist';
+        self::expectException(InvalidParamsException::class);
+        self::expectExceptionCode(Exception::PARAMS_WECHAT_SERIAL_NOT_FOUND);
+        WechatTraitStub::getWechatPublicKey(ProviderConfigTrait::getProviderConfig('wechat'), $serialNo);
+    }
+
+    public function testGetWechatMiniprogramPaySign(): void
+    {
+        self::assertEquals('6bb3e49bb4744fc6817331333ffa435e0d1409c3c900a87637c98265445cbe96', WechatTraitStub::getWechatMiniprogramPaySign(ProviderConfigTrait::getProviderConfig('wechat'), 'yansongda.cn', '{"name":"yansongda"}'));
+
+        self::expectException(InvalidConfigException::class);
+        self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
+        WechatTraitStub::getWechatMiniprogramPaySign([], 'yansongda.cn', '{"name":"yansongda"}');
+    }
+
+    public function testGetWechatMiniprogramUserSign(): void
+    {
+        self::assertEquals('e2bfc507bfee7e1f7029cf204e4a1a848a1d4c64eec279ec2d5be56c675a1bbe', WechatTraitStub::getWechatMiniprogramUserSign('yansongda', '{"name":"yansongda"}'));
     }
 }

--- a/tests/Traits/WechatTraitTest.php
+++ b/tests/Traits/WechatTraitTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yansongda\Pay\Tests\Traits;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Yansongda\Pay\Pay;
+use Yansongda\Pay\Tests\TestCase;
+use Yansongda\Pay\Traits\WechatTrait;
+use Yansongda\Supports\Collection;
+
+class WechatTraitStub
+{
+    use WechatTrait;
+}
+
+class WechatTraitTest extends TestCase
+{
+    public function testGetWechatUrlRelativePath(): void
+    {
+        self::assertSame(
+            \Yansongda\Pay\Provider\Wechat::URL[Pay::MODE_NORMAL].'v3/pay/transactions/jsapi',
+            WechatTraitStub::getWechatUrl([], new Collection(['_url' => 'v3/pay/transactions/jsapi']))
+        );
+    }
+
+    public function testGetWechatMethodDefault(): void
+    {
+        self::assertSame('POST', WechatTraitStub::getWechatMethod(null));
+    }
+
+    public function testVerifyWechatSignSuccess(): void
+    {
+        $timestamp = '1700000000';
+        $nonce = 'nonce123';
+        $body = '{"id":"test"}';
+        $content = $timestamp."\n".$nonce."\n".$body."\n";
+
+        $privateKey = openssl_pkey_get_private(file_get_contents(dirname(__DIR__).'/Cert/wechatAppPrivateKey.pem'));
+        openssl_sign($content, $signature, $privateKey, 'sha256WithRSAEncryption');
+
+        $request = (new ServerRequest('POST', 'https://example.com/wechat'))
+            ->withHeader('Wechatpay-Serial', '45F59D4DABF31918AFCEC556D5D2C6E376675D57')
+            ->withHeader('Wechatpay-Timestamp', $timestamp)
+            ->withHeader('Wechatpay-Nonce', $nonce)
+            ->withHeader('Wechatpay-Signature', base64_encode($signature))
+            ->withBody(\GuzzleHttp\Psr7\Utils::streamFor($body));
+
+        WechatTraitStub::verifyWechatSign($request, []);
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary

v3.8.0 重构 PR 1 - 基础设施与迁移模式验证

### 新增

- **CertManager**: 证书加载与进程内缓存
- **AbstractServiceProvider**: ServiceProvider 抽象基类
- **Provider Traits**: 9 个 Trait（Alipay, Wechat, Unipay, Jsb, Douyin, Paypal, Stripe, ProviderConfig, Support）
- **测试**: 所有新增文件均有对应测试

### 迁移

- Alipay V2 plugins (6 files): 使用 AlipayTrait
- Stripe V1 plugins (3 files): 使用 StripeTrait

### Review 重点

建议重点关注以下核心文件（共10个，而非全部31个）：

| 优先级 | 文件 | 重点 |
|-------|------|------|
| P0 | `src/CertManager.php` | 缓存机制、证书加载 |
| P0 | `src/Service/AbstractServiceProvider.php` | 基类设计 |
| P0 | `src/Traits/WechatTrait.php` | 签名验证、加解密（18方法） |
| P1 | `src/Traits/AlipayTrait.php` | 签名验证实现 |
| P1 | `src/Plugin/Alipay/V2/CallbackPlugin.php` | 回调验签 |
| P1 | `src/Plugin/Stripe/V1/Pay/CallbackPlugin.php` | 回调验签 |
| P2 | `src/Traits/ProviderConfigTrait.php` | 配置获取 |
| P2 | `tests/CertManagerTest.php` | 缓存测试覆盖 |
| P3 | `tests/Traits/WechatTraitTest.php` | 签名测试覆盖 |

### 验证

在 `v3.8-refactoring` 分支已完整验证：
- PHPUnit: 1043 tests, 2336 assertions ✅
- PHPStan Level 5: No errors ✅  
- CS-Fixer: 0 files ✅

### 后续 PR

本 PR 合并后将继续：
- PR 2: 其他 Provider 迁移（Paypal, Douyin, Jsb, Unipay，~70 files）
- PR 3: Wechat 迁移（151 files，最复杂）
- PR 4: 清理收尾（ServiceProvider继承, Functions.php删除, CHANGELOG）

### Breaking Changes

本 PR 无 Breaking Changes，仅新增基础设施。

完整 v3.8.0 Breaking Changes 将在 PR 4 中包含：
- Functions.php 删除
- 函数名改为驼峰（Trait 方法）