### PR TITLE
refactor(v3.8): 迁移 Wechat Plugin 使用 WechatTrait 方法

### DIFF
--- a/src/Plugin/Wechat/AddRadarPlugin.php
+++ b/src/Plugin/Wechat/AddRadarPlugin.php
@@ -13,14 +13,13 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_body;
-use function Yansongda\Pay\get_wechat_method;
-use function Yansongda\Pay\get_wechat_url;
 
 class AddRadarPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,13 +31,13 @@ class AddRadarPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         $rocket->setRadar(new Request(
-            get_wechat_method($payload),
-            get_wechat_url($config, $payload),
+            self::getWechatMethod($payload),
+            self::getWechatUrl($config, $payload),
             $this->getHeaders($payload),
-            get_wechat_body($payload),
+            self::getWechatBody($payload),
         ));
 
         Logger::info('[Wechat][AddRadarPlugin] 插件装载完毕', ['rocket' => $rocket]);

--- a/src/Plugin/Wechat/AddRadarPlugin.php
+++ b/src/Plugin/Wechat/AddRadarPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\InvalidParamsException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 class AddRadarPlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V2/AddPayloadSignaturePlugin.php
+++ b/src/Plugin/Wechat/V2/AddPayloadSignaturePlugin.php
@@ -13,11 +13,12 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign_v2;
+use Yansongda\Pay\Traits\WechatTrait;
 
 class AddPayloadSignaturePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -27,10 +28,10 @@ class AddPayloadSignaturePlugin implements PluginInterface
     {
         Logger::debug('[Wechat][V2][AddPayloadSignaturePlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
 
         $rocket->mergePayload([
-            'sign' => get_wechat_sign_v2($config, filter_params($rocket->getPayload())->all()),
+            'sign' => self::getWechatSignV2($config, filter_params($rocket->getPayload())->all()),
         ]);
 
         Logger::info('[Wechat][V2][AddPayloadSignaturePlugin] 插件装载完毕', ['rocket' => $rocket]);

--- a/src/Plugin/Wechat/V2/AddPayloadSignaturePlugin.php
+++ b/src/Plugin/Wechat/V2/AddPayloadSignaturePlugin.php
@@ -11,9 +11,9 @@ use Yansongda\Artful\Exception\InvalidConfigException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 class AddPayloadSignaturePlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V2/Papay/Direct/ApplyPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/ApplyPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Str;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Str;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_8.shtml

--- a/src/Plugin/Wechat/V2/Papay/Direct/ApplyPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/ApplyPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_8.shtml
  */
 class ApplyPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -32,14 +33,14 @@ class ApplyPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Papay][Direct][ApplyPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setPacker(XmlPacker::class)
             ->mergePayload([
                 '_url' => 'pay/pappayapply',
                 '_content_type' => 'application/xml',
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
                 'nonce_str' => Str::random(32),
                 'sign_type' => 'MD5',

--- a/src/Plugin/Wechat/V2/Papay/Direct/ContractOrderPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/ContractOrderPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Str;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Str;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_5.shtml

--- a/src/Plugin/Wechat/V2/Papay/Direct/ContractOrderPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/ContractOrderPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_5.shtml
  */
 class ContractOrderPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -32,16 +33,16 @@ class ContractOrderPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Papay][Direct][ContractOrderPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setPacker(XmlPacker::class)
             ->mergePayload([
                 '_url' => 'pay/contractorder',
                 '_content_type' => 'application/xml',
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
-                'contract_appid' => $config[get_wechat_type_key($params)] ?? '',
+                'contract_appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'contract_mchid' => $config['mch_id'] ?? '',
                 'nonce_str' => Str::random(32),
                 'sign_type' => 'MD5',

--- a/src/Plugin/Wechat/V2/Papay/Direct/MiniOnlyContractPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/MiniOnlyContractPlugin.php
@@ -11,15 +11,16 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_3.shtml
  */
 class MiniOnlyContractPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -29,12 +30,12 @@ class MiniOnlyContractPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Papay][Direct][OnlyContractPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDirection(NoHttpRequestDirection::class)
             ->mergePayload([
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
                 'notify_url' => $payload?->get('notify_url') ?? $config['notify_url'] ?? '',
                 'timestamp' => time(),

--- a/src/Plugin/Wechat/V2/Papay/Direct/MiniOnlyContractPlugin.php
+++ b/src/Plugin/Wechat/V2/Papay/Direct/MiniOnlyContractPlugin.php
@@ -13,7 +13,6 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/papay/chapter3_3.shtml
  */

--- a/src/Plugin/Wechat/V2/Pay/App/InvokePlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/App/InvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_12&index=2

--- a/src/Plugin/Wechat/V2/Pay/App/InvokePlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/App/InvokePlugin.php
@@ -18,15 +18,16 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign_v2;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_12&index=2
  */
 class InvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws Exception
@@ -51,7 +52,7 @@ class InvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -76,7 +77,7 @@ class InvokePlugin implements PluginInterface
             'timestamp' => time().'',
         ]);
 
-        $invokeConfig->set('sign', get_wechat_sign_v2($config, $invokeConfig->all()));
+        $invokeConfig->set('sign', self::getWechatSignV2($config, $invokeConfig->all()));
 
         return $invokeConfig;
     }

--- a/src/Plugin/Wechat/V2/Pay/Mini/InvokePlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Mini/InvokePlugin.php
@@ -18,15 +18,16 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign_v2;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxa/wxa_api.php?chapter=7_7&index=5
  */
 class InvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws Exception
@@ -51,7 +52,7 @@ class InvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -75,7 +76,7 @@ class InvokePlugin implements PluginInterface
             'signType' => 'MD5',
         ]);
 
-        $invokeConfig->set('paySign', get_wechat_sign_v2($config, $invokeConfig->all()));
+        $invokeConfig->set('paySign', self::getWechatSignV2($config, $invokeConfig->all()));
 
         return $invokeConfig;
     }

--- a/src/Plugin/Wechat/V2/Pay/Mini/InvokePlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Mini/InvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/wxa/wxa_api.php?chapter=7_7&index=5

--- a/src/Plugin/Wechat/V2/Pay/Pos/CancelPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/CancelPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Str;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Str;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_11&index=3

--- a/src/Plugin/Wechat/V2/Pay/Pos/CancelPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/CancelPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_11&index=3
  */
 class CancelPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -32,13 +33,13 @@ class CancelPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Pay][Pos][CancelPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         $rocket->setPacker(XmlPacker::class)
             ->mergePayload([
                 '_url' => 'secapi/pay/reverse',
                 '_content_type' => 'application/xml',
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
                 'nonce_str' => Str::random(32),
                 'sign_type' => 'MD5',

--- a/src/Plugin/Wechat/V2/Pay/Pos/PayPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/PayPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_10&index=1
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -32,13 +33,13 @@ class PayPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Pay][Pos][PayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         $rocket->setPacker(XmlPacker::class)
             ->mergePayload([
                 '_url' => 'pay/micropay',
                 '_content_type' => 'application/xml',
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
                 'nonce_str' => Str::random(32),
                 'sign_type' => 'MD5',

--- a/src/Plugin/Wechat/V2/Pay/Pos/PayPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/PayPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Str;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Str;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_10&index=1

--- a/src/Plugin/Wechat/V2/Pay/Pos/QueryPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/QueryPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_02
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -32,13 +33,13 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Pay][Pos][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         $rocket->setPacker(XmlPacker::class)
             ->mergePayload([
                 '_url' => 'pay/orderquery',
                 '_content_type' => 'application/xml',
-                'appid' => $config[get_wechat_type_key($params)] ?? '',
+                'appid' => $config[self::getWechatTypeKey($params)] ?? '',
                 'mch_id' => $config['mch_id'] ?? '',
                 'nonce_str' => Str::random(32),
                 'sign_type' => 'MD5',

--- a/src/Plugin/Wechat/V2/Pay/Pos/QueryPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Pos/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
-use Yansongda\Supports\Str;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Str;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/micropay.php?chapter=9_02

--- a/src/Plugin/Wechat/V2/Pay/Redpack/SendPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Redpack/SendPlugin.php
@@ -13,10 +13,9 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Packer\XmlPacker;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon_sl.php?chapter=13_4&index=3

--- a/src/Plugin/Wechat/V2/Pay/Redpack/SendPlugin.php
+++ b/src/Plugin/Wechat/V2/Pay/Redpack/SendPlugin.php
@@ -15,15 +15,16 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon_sl.php?chapter=13_4&index=3
  */
 class SendPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -34,7 +35,7 @@ class SendPlugin implements PluginInterface
         Logger::debug('[Wechat][V2][Pay][Redpack][SendPlugin] 插件开始装载', ['rocket' => $rocket]);
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (Pay::MODE_SERVICE === ($config['mode'] ?? Pay::MODE_NORMAL)) {
             $data = $this->service($payload, $config, $params);
@@ -62,14 +63,14 @@ class SendPlugin implements PluginInterface
     protected function normal(array $config, array $params): array
     {
         return [
-            'wxappid' => $config[get_wechat_type_key($params)] ?? '',
+            'wxappid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mch_id' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $config, array $params): array
     {
-        $wechatTypeKey = get_wechat_type_key($params);
+        $wechatTypeKey = self::getWechatTypeKey($params);
 
         return [
             'wxappid' => $config[$wechatTypeKey] ?? '',

--- a/src/Plugin/Wechat/V2/VerifySignaturePlugin.php
+++ b/src/Plugin/Wechat/V2/VerifySignaturePlugin.php
@@ -14,11 +14,12 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\InvalidSignException;
 
 use function Yansongda\Artful\should_do_http_request;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\verify_wechat_sign_v2;
+use Yansongda\Pay\Traits\WechatTrait;
 
 class VerifySignaturePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -32,13 +33,13 @@ class VerifySignaturePlugin implements PluginInterface
 
         Logger::debug('[Wechat][V2][VerifySignaturePlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
 
         if (!should_do_http_request($rocket->getDirection())) {
             return $rocket;
         }
 
-        verify_wechat_sign_v2($config, $rocket->getDestination()?->all() ?? []);
+        self::verifyWechatSignV2($config, $rocket->getDestination()?->all() ?? []);
 
         Logger::info('[Wechat][V2][VerifySignaturePlugin] 插件装载完毕', ['rocket' => $rocket]);
 

--- a/src/Plugin/Wechat/V2/VerifySignaturePlugin.php
+++ b/src/Plugin/Wechat/V2/VerifySignaturePlugin.php
@@ -12,9 +12,9 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\WechatTrait;
 
 use function Yansongda\Artful\should_do_http_request;
-use Yansongda\Pay\Traits\WechatTrait;
 
 class VerifySignaturePlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V3/AddPayloadSignaturePlugin.php
+++ b/src/Plugin/Wechat/V3/AddPayloadSignaturePlugin.php
@@ -17,15 +17,13 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Str;
 
-use function Yansongda\Pay\get_provider_config;
 use function Yansongda\Pay\get_public_cert;
-use function Yansongda\Pay\get_wechat_body;
-use function Yansongda\Pay\get_wechat_method;
-use function Yansongda\Pay\get_wechat_sign;
-use function Yansongda\Pay\get_wechat_url;
+use Yansongda\Pay\Traits\WechatTrait;
 
 class AddPayloadSignaturePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -37,7 +35,7 @@ class AddPayloadSignaturePlugin implements PluginInterface
     {
         Logger::debug('[Wechat][V3][AddPayloadSignaturePlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
 
         $timestamp = time();
@@ -57,15 +55,15 @@ class AddPayloadSignaturePlugin implements PluginInterface
      */
     protected function getSignatureContent(array $config, ?Collection $payload, int $timestamp, string $random): string
     {
-        $url = get_wechat_url($config, $payload);
+        $url = self::getWechatUrl($config, $payload);
         $urlPath = parse_url($url, PHP_URL_PATH);
         $urlQuery = parse_url($url, PHP_URL_QUERY);
 
-        return get_wechat_method($payload)."\n"
+        return self::getWechatMethod($payload)."\n"
             .$urlPath.(empty($urlQuery) ? '' : '?'.$urlQuery)."\n"
             .$timestamp."\n"
             .$random."\n"
-            .get_wechat_body($payload)."\n";
+            .self::getWechatBody($payload)."\n";
     }
 
     /**
@@ -91,7 +89,7 @@ class AddPayloadSignaturePlugin implements PluginInterface
             $random,
             $timestamp,
             $ssl['serialNumberHex'],
-            get_wechat_sign($config, $contents),
+            self::getWechatSign($config, $contents),
         );
 
         return 'WECHATPAY2-SHA256-RSA2048 '.$auth;

--- a/src/Plugin/Wechat/V3/AddPayloadSignaturePlugin.php
+++ b/src/Plugin/Wechat/V3/AddPayloadSignaturePlugin.php
@@ -14,11 +14,11 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Str;
 
 use function Yansongda\Pay\get_public_cert;
-use Yansongda\Pay\Traits\WechatTrait;
 
 class AddPayloadSignaturePlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V3/CallbackPlugin.php
+++ b/src/Plugin/Wechat/V3/CallbackPlugin.php
@@ -17,9 +17,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 class CallbackPlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V3/CallbackPlugin.php
+++ b/src/Plugin/Wechat/V3/CallbackPlugin.php
@@ -18,13 +18,13 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\decrypt_wechat_resource;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\verify_wechat_sign;
 
 class CallbackPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -42,13 +42,13 @@ class CallbackPlugin implements PluginInterface
         $params = $rocket->getParams();
 
         /* @phpstan-ignore-next-line */
-        verify_wechat_sign($rocket->getDestinationOrigin(), $params);
+        self::verifyWechatSign($rocket->getDestinationOrigin(), $params);
 
         $body = json_decode((string) $rocket->getDestination()->getBody(), true);
 
         $rocket->setDirection(NoHttpRequestDirection::class)->setPayload(new Collection($body));
 
-        $body['resource'] = decrypt_wechat_resource($body['resource'] ?? [], get_provider_config('wechat', $params));
+        $body['resource'] = self::decryptWechatResource($body['resource'] ?? [], self::getProviderConfig('wechat', $params));
 
         $rocket->setDestination(new Collection($body));
 

--- a/src/Plugin/Wechat/V3/Extend/Complaints/CompletePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/CompletePlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/complete-complaint-v2.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class CompletePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class CompletePlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Extend][Complaints][CompletePlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $complaintId = $payload?->get('complaint_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Extend/Complaints/CompletePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/CompletePlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/complete-complaint-v2.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/consumer-complaint/complaints/complete-complaint-v2.html

--- a/src/Plugin/Wechat/V3/Extend/Complaints/QueryDetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/QueryDetailPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\decrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/query-complaint-v2.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryDetailPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws InvalidConfigException
@@ -56,7 +57,7 @@ class QueryDetailPlugin implements PluginInterface
         $destination = $rocket->getDestination();
 
         if ($destination instanceof Collection && !empty($payerPhone = $destination->get('payer_phone'))) {
-            $decryptPayerPhone = decrypt_wechat_contents($payerPhone, get_provider_config('wechat', $rocket->getParams()));
+            $decryptPayerPhone = self::decryptWechatContents($payerPhone, self::getProviderConfig('wechat', $rocket->getParams()));
 
             if (empty($decryptPayerPhone)) {
                 throw new InvalidConfigException(Exception::DECRYPT_WECHAT_ENCRYPTED_CONTENTS_INVALID, '参数异常: 查询投诉单详情，参数 `payer_phone` 解密失败');

--- a/src/Plugin/Wechat/V3/Extend/Complaints/QueryDetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/QueryDetailPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/query-complaint-v2.html

--- a/src/Plugin/Wechat/V3/Extend/Complaints/ResponsePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/ResponsePlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/response-complaint-v2.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/consumer-complaint/complaints/response-complaint-v2.html

--- a/src/Plugin/Wechat/V3/Extend/Complaints/ResponsePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/Complaints/ResponsePlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/consumer-complaint/complaints/response-complaint-v2.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ResponsePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class ResponsePlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Extend][Complaints][ResponsePlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $complaintId = $payload?->get('complaint_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/AddReceiverPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/AddReceiverPlugin.php
@@ -16,12 +16,8 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\encrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_public_key;
-use function Yansongda\Pay\get_wechat_serial_no;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/receivers/add-receiver.html
@@ -29,6 +25,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class AddReceiverPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws DecryptException
@@ -41,7 +39,7 @@ class AddReceiverPlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][AddReceiverPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -76,7 +74,7 @@ class AddReceiverPlugin implements PluginInterface
     protected function normal(Collection $payload, array $params, array $config): array
     {
         $data = [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
         ];
 
         if (!$payload->has('name')) {
@@ -95,7 +93,7 @@ class AddReceiverPlugin implements PluginInterface
      */
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $wechatTypeKey = get_wechat_type_key($params);
+        $wechatTypeKey = self::getWechatTypeKey($params);
 
         $data = [
             'sub_mchid' => $payload->get('sub_mchid', $config['sub_mch_id'] ?? ''),
@@ -122,12 +120,12 @@ class AddReceiverPlugin implements PluginInterface
      */
     protected function encryptSensitiveData(array $params, array $config, Collection $payload): array
     {
-        $data['_serial_no'] = get_wechat_serial_no($params);
+        $data['_serial_no'] = self::getWechatSerialNo($params);
 
-        $config = get_provider_config('wechat', $params);
-        $publicKey = get_wechat_public_key($config, $data['_serial_no']);
+        $config = self::getProviderConfig('wechat', $params);
+        $publicKey = self::getWechatPublicKey($config, $data['_serial_no']);
 
-        $data['name'] = encrypt_wechat_contents($payload->get('name'), $publicKey);
+        $data['name'] = self::encryptWechatContents($payload->get('name'), $publicKey);
 
         return $data;
     }

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/AddReceiverPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/AddReceiverPlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/receivers/add-receiver.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/CreatePlugin.php
@@ -16,12 +16,8 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\encrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_public_key;
-use function Yansongda\Pay\get_wechat_serial_no;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/create-order.html
@@ -29,6 +25,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class CreatePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws DecryptException
@@ -41,7 +39,7 @@ class CreatePlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][CreatePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -76,7 +74,7 @@ class CreatePlugin implements PluginInterface
     protected function normal(Collection $payload, array $params, array $config): array
     {
         $data = [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
         ];
 
         if (!$payload->has('receivers.0.name')) {
@@ -95,7 +93,7 @@ class CreatePlugin implements PluginInterface
      */
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $wechatTypeKey = get_wechat_type_key($params);
+        $wechatTypeKey = self::getWechatTypeKey($params);
 
         $data = [
             'sub_mchid' => $payload->get('sub_mchid', $config['sub_mch_id'] ?? ''),
@@ -123,13 +121,13 @@ class CreatePlugin implements PluginInterface
     protected function encryptSensitiveData(array $params, Collection $payload): array
     {
         $data['receivers'] = $payload->get('receivers', []);
-        $data['_serial_no'] = get_wechat_serial_no($params);
+        $data['_serial_no'] = self::getWechatSerialNo($params);
 
-        $config = get_provider_config('wechat', $params);
-        $publicKey = get_wechat_public_key($config, $data['_serial_no']);
+        $config = self::getProviderConfig('wechat', $params);
+        $publicKey = self::getWechatPublicKey($config, $data['_serial_no']);
 
         foreach ($data['receivers'] as $key => $list) {
-            $data['receivers'][$key]['name'] = encrypt_wechat_contents($list['name'], $publicKey);
+            $data['receivers'][$key]['name'] = self::encryptWechatContents($list['name'], $publicKey);
         }
 
         return $data;

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/CreatePlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/create-order.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/DeleteReceiverPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/DeleteReceiverPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/receivers/delete-receiver.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/DeleteReceiverPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/DeleteReceiverPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/receivers/delete-receiver.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class DeleteReceiverPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +35,7 @@ class DeleteReceiverPlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][DeleteReceiverPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -62,13 +63,13 @@ class DeleteReceiverPlugin implements PluginInterface
     protected function normal(array $params, array $config): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $wechatTypeKEY = get_wechat_type_key($params);
+        $wechatTypeKEY = self::getWechatTypeKey($params);
 
         $data = [
             'sub_mchid' => $payload->get('sub_mchid', $config['sub_mch_id'] ?? ''),

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryMerchantConfigsPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryMerchantConfigsPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/profit-sharing/merchants/query-merchant-ratio.html
  */
 class QueryMerchantConfigsPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class QueryMerchantConfigsPlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][QueryMerchantConfigsPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $subMchId = $payload?->get('sub_mch_id') ?? $config['sub_mch_id'] ?? 'null';
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryMerchantConfigsPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryMerchantConfigsPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/profit-sharing/merchants/query-merchant-ratio.html
  */

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/query-order.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/profit-sharing/orders/query-order.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/query-order.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -30,7 +32,7 @@ class QueryPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Extend][ProfitSharing][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $outOrderNo = $payload?->get('out_order_no') ?? null;
         $transactionId = $payload?->get('transaction_id') ?? null;

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryReturnPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryReturnPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/return-orders/query-return-order.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/profit-sharing/return-orders/query-return-order.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryReturnPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/QueryReturnPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/return-orders/query-return-order.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryReturnPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -30,7 +32,7 @@ class QueryReturnPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Extend][ProfitSharing][QueryReturnPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $outOrderNo = $payload?->get('out_order_no') ?? null;
         $outReturnNo = $payload?->get('out_return_no') ?? null;

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/ReturnPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/ReturnPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/return-orders/create-return-order.html

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/ReturnPlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/ReturnPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/return-orders/create-return-order.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ReturnPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class ReturnPlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][ReturnPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/UnfreezePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/UnfreezePlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/unfreeze-order.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class UnfreezePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class UnfreezePlugin implements PluginInterface
         Logger::debug('[Wechat][Extend][ProfitSharing][UnfreezePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Extend/ProfitSharing/UnfreezePlugin.php
+++ b/src/Plugin/Wechat/V3/Extend/ProfitSharing/UnfreezePlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/profit-sharing/orders/unfreeze-order.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/QueryPlugin.php
@@ -12,7 +12,6 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/call-back-url/query-callback.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/call-back-url/query-callback.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/QueryPlugin.php
@@ -10,8 +10,8 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/call-back-url/query-callback.html
@@ -19,6 +19,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -28,7 +30,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][Marketing][Coupon][Callback][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $mchId = $rocket->getPayload()?->get('mchid') ?? $config['mch_id'] ?? 'null';
 
         $rocket->setPayload([

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/SetPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/SetPlugin.php
@@ -10,8 +10,8 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/call-back-url/set-callback.html
@@ -19,6 +19,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class SetPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -28,7 +30,7 @@ class SetPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Callback][SetPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->mergePayload(array_merge(

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/SetPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Callback/SetPlugin.php
@@ -12,7 +12,6 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/call-back-url/set-callback.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/call-back-url/set-callback.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/DetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/DetailPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/query-coupon.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/coupon/query-coupon.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/DetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/DetailPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/query-coupon.html
@@ -22,6 +21,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class DetailPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,11 +33,11 @@ class DetailPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Coupons][DetailPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $openId = $payload?->get('openid') ?? null;
         $couponId = $payload?->get('coupon_id') ?? null;
-        $appId = $payload?->get('appid') ?? $config[get_wechat_type_key($params)] ?? 'null';
+        $appId = $payload?->get('appid') ?? $config[self::getWechatTypeKey($params)] ?? 'null';
 
         if (empty($openId) || empty($couponId)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: 查询代金券详情，参数缺少 `openid` 或 `coupon_id`');

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/QueryUserPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/QueryUserPlugin.php
@@ -12,10 +12,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/list-coupons-by-filter.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/QueryUserPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/QueryUserPlugin.php
@@ -15,8 +15,7 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/list-coupons-by-filter.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class QueryUserPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -34,7 +35,7 @@ class QueryUserPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Coupons][QueryUserPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $openId = $payload?->get('openid') ?? null;
 
@@ -58,7 +59,7 @@ class QueryUserPlugin implements PluginInterface
         $appId = $payload->get('appid');
 
         if (is_null($appId)) {
-            $payload->set('appid', $config[get_wechat_type_key($params)] ?? '');
+            $payload->set('appid', $config[self::getWechatTypeKey($params)] ?? '');
         }
 
         return filter_params($payload)->except('openid')->query();

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/SendPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/SendPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/send-coupon.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/SendPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Coupons/SendPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/coupon/send-coupon.html
@@ -23,6 +22,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class SendPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -33,7 +34,7 @@ class SendPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Coupons][SendPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $openId = $payload?->get('openid') ?? null;
 
@@ -58,7 +59,7 @@ class SendPlugin implements PluginInterface
     protected function normal(Collection $payload, array $params, array $config): array
     {
         if (empty($payload->get('appid'))) {
-            $payload->set('appid', $config[get_wechat_type_key($params)] ?? '');
+            $payload->set('appid', $config[self::getWechatTypeKey($params)] ?? '');
         }
 
         if (empty($payload->get('stock_creator_mchid'))) {

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/CreatePlugin.php
@@ -10,8 +10,8 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/create-coupon-stock.html
@@ -19,6 +19,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class CreatePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -28,7 +30,7 @@ class CreatePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][CreatePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $belongMerchant = $rocket->getPayload()?->get('belong_merchant') ?? $config['mch_id'];
 
         $rocket->mergePayload([

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/CreatePlugin.php
@@ -12,7 +12,6 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/create-coupon-stock.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/stock/create-coupon-stock.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/PausePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/PausePlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/pause-stock.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/stock/pause-stock.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/PausePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/PausePlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/pause-stock.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class PausePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class PausePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][PausePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
         $stockCreatorMchId = $payload?->get('stock_creator_mchid') ?? $config['mch_id'] ?? '';

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryDetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryDetailPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/query-stock.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/stock/query-stock.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryDetailPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryDetailPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/query-stock.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryDetailPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class QueryDetailPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][QueryDetailPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
         $mchId = $payload?->get('stock_creator_mchid') ?? $config['mch_id'] ?? 'null';

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryItemsPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryItemsPlugin.php
@@ -15,7 +15,7 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-available-singleitems.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryItemsPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class QueryItemsPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][QueryItemsPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryItemsPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryItemsPlugin.php
@@ -12,10 +12,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-available-singleitems.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryMerchantsPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryMerchantsPlugin.php
@@ -15,7 +15,7 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-available-merchants.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryMerchantsPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class QueryMerchantsPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][QueryMerchantsPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryMerchantsPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryMerchantsPlugin.php
@@ -12,10 +12,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-available-merchants.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryPlugin.php
@@ -15,7 +15,7 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-stocks.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/QueryPlugin.php
@@ -12,10 +12,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/list-stocks.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/RestartPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/RestartPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/restart-stock.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/stock/restart-stock.html

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/RestartPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/RestartPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/restart-stock.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RestartPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class RestartPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][RestartPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
         $stockCreatorMchId = $payload?->get('stock_creator_mchid') ?? $config['mch_id'] ?? '';

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/StartPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/StartPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/start-stock.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class StartPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class StartPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Coupon][Stock][StartPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $stockId = $payload?->get('stock_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/StartPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Coupon/Stock/StartPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/cash-coupons/stock/start-stock.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/cash-coupons/stock/start-stock.html

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryDayEndPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryDayEndPlugin.php
@@ -13,10 +13,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-balance/accounts/query-day-end-balance.html

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryDayEndPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryDayEndPlugin.php
@@ -16,13 +16,15 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-balance/accounts/query-day-end-balance.html
  */
 class QueryDayEndPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryDayEndPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Marketing][ECommerceBalance][QueryDayEndPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $accountType = $payload?->get('account_type') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-balance/accounts/query-balance.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceBalance/QueryPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-balance/accounts/query-balance.html
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class QueryPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Marketing][ECommerceBalance][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $accountType = $rocket->getPayload()?->get('account_type') ?? null;
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ApplyPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ApplyPlugin.php
@@ -13,15 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/create-refund.html
  */
 class ApplyPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,9 +34,9 @@ class ApplyPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $subMchId = $payload?->get('sub_mchid') ?? $config['sub_mch_id'] ?? '';
-        $spAppId = $payload?->get('sp_appid') ?? $config[get_wechat_type_key($params)] ?? '';
+        $spAppId = $payload?->get('sp_appid') ?? $config[self::getWechatTypeKey($params)] ?? '';
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {
             throw new InvalidParamsException(Exception::PARAMS_PLUGIN_ONLY_SUPPORT_SERVICE_MODE, '参数异常: 平台收付通（退款）-申请退款，只支持服务商模式，当前配置为普通商户模式');

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ApplyPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ApplyPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/create-refund.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryByWxPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-refund.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryByWxPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-refund.html
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $refundId = $payload?->get('refund_id') ?? null;
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-refund-by-out-refund-no.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-refund-by-out-refund-no.html
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryReturnAdvancePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryReturnAdvancePlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-return-advance.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryReturnAdvancePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/QueryReturnAdvancePlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/query-return-advance.html
  */
 class QueryReturnAdvancePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryReturnAdvancePlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $refundId = $payload?->get('refund_id') ?? null;
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ReturnAdvancePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ReturnAdvancePlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/create-return-advance.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ReturnAdvancePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/ECommerceRefund/ReturnAdvancePlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/partner/apis/ecommerce-refund/refunds/create-return-advance.html
  */
 class ReturnAdvancePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class ReturnAdvancePlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $refundId = $payload?->get('refund_id') ?? null;
 
         if (Pay::MODE_NORMAL === ($config['mode'] ?? Pay::MODE_NORMAL)) {

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/Blockchain/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/Blockchain/CreatePlugin.php
@@ -14,17 +14,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\encrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_public_key;
-use function Yansongda\Pay\get_wechat_serial_no;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/fapiao/fapiao-applications/issue-fapiao-applications.html
  */
 class CreatePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws DecryptException
@@ -38,7 +37,7 @@ class CreatePlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         $rocket->mergePayload(array_merge([
             '_method' => 'POST',
@@ -59,20 +58,20 @@ class CreatePlugin implements PluginInterface
      */
     protected function encryptSensitiveData(?Collection $payload, array $params, array $config): array
     {
-        $data['_serial_no'] = get_wechat_serial_no($params);
+        $data['_serial_no'] = self::getWechatSerialNo($params);
 
-        $config = get_provider_config('wechat', $params);
-        $publicKey = get_wechat_public_key($config, $data['_serial_no']);
+        $config = self::getProviderConfig('wechat', $params);
+        $publicKey = self::getWechatPublicKey($config, $data['_serial_no']);
 
         $phone = $payload?->get('buyer_information.phone') ?? null;
         $email = $payload?->get('buyer_information.email') ?? null;
 
         if (!is_null($phone)) {
-            $data['buyer_information']['phone'] = encrypt_wechat_contents($phone, $publicKey);
+            $data['buyer_information']['phone'] = self::encryptWechatContents($phone, $publicKey);
         }
 
         if (!is_null($email)) {
-            $data['buyer_information']['email'] = encrypt_wechat_contents($email, $publicKey);
+            $data['buyer_information']['email'] = self::encryptWechatContents($email, $publicKey);
         }
 
         return $data;

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/Blockchain/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/Blockchain/CreatePlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/fapiao/fapiao-applications/issue-fapiao-applications.html

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/CreateCardTemplatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/CreateCardTemplatePlugin.php
@@ -10,14 +10,16 @@ use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/products/fapiao/apilist.html
  */
 class CreateCardTemplatePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -27,7 +29,7 @@ class CreateCardTemplatePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Marketing][Fapiao][CreateCardTemplatePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->mergePayload([

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/CreateCardTemplatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/CreateCardTemplatePlugin.php
@@ -12,7 +12,6 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/products/fapiao/apilist.html
  */

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/GetTitleUrlPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/GetTitleUrlPlugin.php
@@ -12,10 +12,10 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/fapiao/user-title/acquire-fapiao-title-url.html

--- a/src/Plugin/Wechat/V3/Marketing/Fapiao/GetTitleUrlPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Fapiao/GetTitleUrlPlugin.php
@@ -15,14 +15,15 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
 
 use function Yansongda\Artful\filter_params;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
+use Yansongda\Pay\Traits\WechatTrait;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/fapiao/user-title/acquire-fapiao-title-url.html
  */
 class GetTitleUrlPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -55,10 +56,10 @@ class GetTitleUrlPlugin implements PluginInterface
      */
     protected function getQuery(Collection $payload, array $params): Collection
     {
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         return filter_params($payload)->merge([
-            'appid' => $payload->get('appid', $config[get_wechat_type_key($params)] ?? ''),
+            'appid' => $payload->get('appid', $config[self::getWechatTypeKey($params)] ?? ''),
         ]);
     }
 }

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/CancelPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/CancelPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716458
  */

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/CancelPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/CancelPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716458
  */
 class CancelPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class CancelPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Marketing][Transfer][CancelPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $outBillNo = $payload?->get('out_bill_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/CreatePlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716434

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/CreatePlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/CreatePlugin.php
@@ -16,18 +16,16 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\encrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_public_key;
-use function Yansongda\Pay\get_wechat_serial_no;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716434
  */
 class CreatePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws DecryptException
@@ -41,7 +39,7 @@ class CreatePlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (Pay::MODE_SERVICE === ($config['mode'] ?? Pay::MODE_NORMAL)) {
             throw new InvalidParamsException(Exception::PARAMS_PLUGIN_ONLY_SUPPORT_NORMAL_MODE, '参数异常: 发起商家转账，只支持普通商户模式，当前配置为服务商模式');
@@ -55,7 +53,7 @@ class CreatePlugin implements PluginInterface
             [
                 '_method' => 'POST',
                 '_url' => 'v3/fund-app/mch-transfer/transfer-bills',
-                'appid' => $payload->get('appid', $config[get_wechat_type_key($params)] ?? ''),
+                'appid' => $payload->get('appid', $config[self::getWechatTypeKey($params)] ?? ''),
                 'notify_url' => $payload->get('notify_url', $config['notify_url'] ?? ''),
             ],
             $this->normal($params, $payload)
@@ -91,12 +89,12 @@ class CreatePlugin implements PluginInterface
      */
     protected function encryptSensitiveData(array $params, Collection $payload): array
     {
-        $data['_serial_no'] = get_wechat_serial_no($params);
+        $data['_serial_no'] = self::getWechatSerialNo($params);
 
-        $config = get_provider_config('wechat', $params);
-        $publicKey = get_wechat_public_key($config, $data['_serial_no']);
+        $config = self::getProviderConfig('wechat', $params);
+        $publicKey = self::getWechatPublicKey($config, $data['_serial_no']);
 
-        $data['user_name'] = encrypt_wechat_contents($payload->get('user_name'), $publicKey);
+        $data['user_name'] = self::encryptWechatContents($payload->get('user_name'), $publicKey);
 
         return $data;
     }

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeAndroidPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeAndroidPlugin.php
@@ -14,10 +14,9 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012719576

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeAndroidPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeAndroidPlugin.php
@@ -16,15 +16,16 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012719576
  */
 class InvokeAndroidPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidResponseException
@@ -38,7 +39,7 @@ class InvokeAndroidPlugin implements PluginInterface
 
         Logger::debug('[Wechat][V3][Marketing][Transfer][InvokeAndroidPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $destination = $rocket->getDestination();
         $packageInfo = $destination?->get('package_info');
 
@@ -53,7 +54,7 @@ class InvokeAndroidPlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $params, $config, $packageInfo));
@@ -68,7 +69,7 @@ class InvokeAndroidPlugin implements PluginInterface
         return new Config([
             'businessType' => 'requestMerchantTransfer',
             'query' => http_build_query([
-                'appId' => $payload?->get('_invoke_appId') ?? $config[get_wechat_type_key($params)] ?? '',
+                'appId' => $payload?->get('_invoke_appId') ?? $config[self::getWechatTypeKey($params)] ?? '',
                 'mchId' => $payload?->get('_invoke_mchId') ?? $config['mch_id'] ?? '',
                 'package' => $packageInfo,
             ]),

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeIosPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeIosPlugin.php
@@ -16,15 +16,16 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012719578
  */
 class InvokeIosPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidResponseException
@@ -38,7 +39,7 @@ class InvokeIosPlugin implements PluginInterface
 
         Logger::debug('[Wechat][V3][Marketing][Transfer][InvokeIosPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $destination = $rocket->getDestination();
         $packageInfo = $destination?->get('package_info');
 
@@ -53,7 +54,7 @@ class InvokeIosPlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $params, $config, $packageInfo));
@@ -68,7 +69,7 @@ class InvokeIosPlugin implements PluginInterface
         return new Config([
             'businessType' => 'requestMerchantTransfer',
             'query' => http_build_query([
-                'appId' => $payload?->get('_invoke_appId') ?? $config[get_wechat_type_key($params)] ?? '',
+                'appId' => $payload?->get('_invoke_appId') ?? $config[self::getWechatTypeKey($params)] ?? '',
                 'mchId' => $payload?->get('_invoke_mchId') ?? $config['mch_id'] ?? '',
                 'package' => $packageInfo,
             ]),

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeIosPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeIosPlugin.php
@@ -14,10 +14,9 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012719578

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeJsapiPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeJsapiPlugin.php
@@ -16,15 +16,16 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716430
  */
 class InvokeJsapiPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidResponseException
@@ -38,7 +39,7 @@ class InvokeJsapiPlugin implements PluginInterface
 
         Logger::debug('[Wechat][V3][Marketing][Transfer][InvokeJsapiPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $destination = $rocket->getDestination();
         $packageInfo = $destination?->get('package_info');
 
@@ -53,7 +54,7 @@ class InvokeJsapiPlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $params, $config, $packageInfo));
@@ -66,7 +67,7 @@ class InvokeJsapiPlugin implements PluginInterface
     protected function getInvokeConfig(?Collection $payload, array $params, array $config, string $packageInfo): Config
     {
         return new Config([
-            'appId' => $payload?->get('_invoke_appId') ?? $config[get_wechat_type_key($params)] ?? '',
+            'appId' => $payload?->get('_invoke_appId') ?? $config[self::getWechatTypeKey($params)] ?? '',
             'mchId' => $payload?->get('_invoke_mchId') ?? $config['mch_id'] ?? '',
             'package' => $packageInfo,
         ]);

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeJsapiPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/InvokeJsapiPlugin.php
@@ -14,10 +14,9 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716430

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/QueryByWxPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716457
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class QueryByWxPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Marketing][Transfer][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $transferBillNo = $payload?->get('transfer_bill_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/QueryByWxPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716457
  */

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/QueryPlugin.php
@@ -13,14 +13,16 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716437
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -30,7 +32,7 @@ class QueryPlugin implements PluginInterface
     {
         Logger::debug('[Wechat][Marketing][Transfer][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
-        $config = get_provider_config('wechat', $rocket->getParams());
+        $config = self::getProviderConfig('wechat', $rocket->getParams());
         $payload = $rocket->getPayload();
         $outBillNo = $payload?->get('out_bill_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Marketing/Transfer/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Marketing/Transfer/QueryPlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/doc/v3/merchant/4012716437
  */

--- a/src/Plugin/Wechat/V3/Pay/App/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/ClosePlugin.php
@@ -15,8 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/close-order.html
@@ -24,6 +24,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][App][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/App/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/ClosePlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/App/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/InvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/app-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/App/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/InvokePlugin.php
@@ -18,9 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/app-transfer-payment.html
@@ -28,6 +27,8 @@ use function Yansongda\Pay\get_wechat_sign;
  */
 class InvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -52,7 +53,7 @@ class InvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -92,7 +93,7 @@ class InvokePlugin implements PluginInterface
             .$invokeConfig->get('noncestr', '')."\n"
             .$invokeConfig->get('prepayid', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config): string

--- a/src/Plugin/Wechat/V3/Pay/App/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/PayPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/direct-jsons/app-prepay.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: APP下单，参数为空');

--- a/src/Plugin/Wechat/V3/Pay/App/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/PayPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/direct-jsons/app-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/App/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryByWxPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-wx-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/App/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryByWxPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-wx-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][App][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $transactionId = $payload?->get('transaction_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/App/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-out-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/App/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-out-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][App][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/App/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/partner-in-app-payment/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/App/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][App][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/App/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/create.html

--- a/src/Plugin/Wechat/V3/Pay/App/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/App/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/in-app-payment/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][App][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Combine/AppInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/AppInvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/app-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/AppInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/AppInvokePlugin.php
@@ -18,9 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/app-transfer-payment.html
@@ -28,6 +27,8 @@ use function Yansongda\Pay\get_wechat_sign;
  */
 class AppInvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -52,7 +53,7 @@ class AppInvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -92,7 +93,7 @@ class AppInvokePlugin implements PluginInterface
             .$invokeConfig->get('noncestr', '')."\n"
             .$invokeConfig->get('prepayid', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config): string

--- a/src/Plugin/Wechat/V3/Pay/Combine/AppPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/AppPayPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/app-prepay.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class AppPayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class AppPayPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][AppPayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Combine/AppPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/AppPayPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/app-prepay.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/app-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/ClosePlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/close-order.html
@@ -23,6 +22,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +34,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $combineOutTradeNo = $payload?->get('combine_out_trade_no') ?? null;
 
@@ -46,7 +47,7 @@ class ClosePlugin implements PluginInterface
                 '_method' => 'POST',
                 '_url' => 'v3/combine-transactions/out-trade-no/'.$combineOutTradeNo.'/close',
                 '_service_url' => 'v3/combine-transactions/out-trade-no/'.$combineOutTradeNo.'/close',
-                'combine_appid' => $payload->get('combine_appid', $config[get_wechat_type_key($params)] ?? ''),
+                'combine_appid' => $payload->get('combine_appid', $config[self::getWechatTypeKey($params)] ?? ''),
             ])
             ->exceptPayload('combine_out_trade_no');
 

--- a/src/Plugin/Wechat/V3/Pay/Combine/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/ClosePlugin.php
@@ -15,7 +15,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/close-order.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/H5PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/H5PayPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/h5-prepay.html
@@ -22,6 +21,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class H5PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +33,7 @@ class H5PayPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][H5PayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -44,7 +45,7 @@ class H5PayPlugin implements PluginInterface
             '_url' => 'v3/combine-transactions/h5',
             '_service_url' => 'v3/combine-transactions/h5',
             'notify_url' => $payload->get('notify_url', $config['notify_url'] ?? ''),
-            'combine_appid' => $payload->get('combine_appid', $config[get_wechat_type_key($params)] ?? ''),
+            'combine_appid' => $payload->get('combine_appid', $config[self::getWechatTypeKey($params)] ?? ''),
             'combine_mchid' => $payload->get('combine_mchid', $config['mch_id'] ?? ''),
         ]);
 

--- a/src/Plugin/Wechat/V3/Pay/Combine/H5PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/H5PayPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/h5-prepay.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/h5-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/JsapiInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/JsapiInvokePlugin.php
@@ -18,10 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/jsapi-transfer-payment.html
@@ -29,6 +27,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class JsapiInvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -53,7 +53,7 @@ class JsapiInvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $params, $config, $prepayId));
@@ -92,15 +92,15 @@ class JsapiInvokePlugin implements PluginInterface
             .$invokeConfig->get('nonceStr', '')."\n"
             .$invokeConfig->get('package', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config, array $params): string
     {
         if (Pay::MODE_SERVICE === ($config['mode'] ?? Pay::MODE_NORMAL)) {
-            return $payload?->get('_invoke_appid') ?? $config['sub_'.get_wechat_type_key($params)] ?? '';
+            return $payload?->get('_invoke_appid') ?? $config['sub_'.self::getWechatTypeKey($params)] ?? '';
         }
 
-        return $payload?->get('_invoke_appid') ?? $config[get_wechat_type_key($params)] ?? '';
+        return $payload?->get('_invoke_appid') ?? $config[self::getWechatTypeKey($params)] ?? '';
     }
 }

--- a/src/Plugin/Wechat/V3/Pay/Combine/JsapiInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/JsapiInvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/jsapi-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/JsapiPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/JsapiPayPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/jsapi-prepay.html
@@ -22,6 +21,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class JsapiPayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +33,7 @@ class JsapiPayPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][JsapiPayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -44,7 +45,7 @@ class JsapiPayPlugin implements PluginInterface
             '_url' => 'v3/combine-transactions/jsapi',
             '_service_url' => 'v3/combine-transactions/jsapi',
             'notify_url' => $payload->get('notify_url', $config['notify_url'] ?? ''),
-            'combine_appid' => $payload->get('combine_appid', $config[get_wechat_type_key($params)] ?? ''),
+            'combine_appid' => $payload->get('combine_appid', $config[self::getWechatTypeKey($params)] ?? ''),
             'combine_mchid' => $payload->get('combine_mchid', $config['mch_id'] ?? ''),
         ]);
 

--- a/src/Plugin/Wechat/V3/Pay/Combine/JsapiPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/JsapiPayPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/jsapi-prepay.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/jsapi-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/MiniInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/MiniInvokePlugin.php
@@ -18,9 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/mini-transfer-payment.html
@@ -28,6 +27,8 @@ use function Yansongda\Pay\get_wechat_sign;
  */
 class MiniInvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -52,7 +53,7 @@ class MiniInvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -91,7 +92,7 @@ class MiniInvokePlugin implements PluginInterface
             .$invokeConfig->get('nonceStr', '')."\n"
             .$invokeConfig->get('package', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config): string

--- a/src/Plugin/Wechat/V3/Pay/Combine/MiniInvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/MiniInvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/mini-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/MiniPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/MiniPayPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/mini-program-prepay.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class MiniPayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -31,7 +33,7 @@ class MiniPayPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][MiniPayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Combine/MiniPayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/MiniPayPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/mini-program-prepay.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/mini-program-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/NativePayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/NativePayPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/native-prepay.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/orders/native-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/NativePayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/NativePayPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/orders/native-prepay.html
@@ -22,6 +21,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class NativePayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +33,7 @@ class NativePayPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][NativePayPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {
@@ -44,7 +45,7 @@ class NativePayPlugin implements PluginInterface
             '_url' => 'v3/combine-transactions/native',
             '_service_url' => 'v3/combine-transactions/native',
             'notify_url' => $payload->get('notify_url', $config['notify_url'] ?? ''),
-            'combine_appid' => $payload->get('combine_appid', $config[get_wechat_type_key($params)] ?? ''),
+            'combine_appid' => $payload->get('combine_appid', $config[self::getWechatTypeKey($params)] ?? ''),
             'combine_mchid' => $payload->get('combine_mchid', $config['mch_id'] ?? ''),
         ]);
 

--- a/src/Plugin/Wechat/V3/Pay/Combine/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/refunds/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Combine/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/refunds/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/combine-payment/refunds/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/Combine/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/refunds/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Combine][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Combine/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Combine/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/combine-payment/refunds/create.html

--- a/src/Plugin/Wechat/V3/Pay/H5/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/ClosePlugin.php
@@ -15,8 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/close-order.html
@@ -24,6 +24,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][H5][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/H5/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/ClosePlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/H5/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/PayPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/direct-jsons/h5-prepay.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -35,7 +36,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: H5 下单，参数为空');
@@ -63,14 +64,14 @@ class PayPlugin implements PluginInterface
     protected function normal(array $params, array $config): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mchid' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $configKey = get_wechat_type_key($params);
+        $configKey = self::getWechatTypeKey($params);
 
         return [
             'sp_appid' => $config[$configKey] ?? '',

--- a/src/Plugin/Wechat/V3/Pay/H5/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/PayPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/direct-jsons/h5-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryByWxPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-wx-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryByWxPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-wx-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][H5][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $transactionId = $payload?->get('transaction_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-out-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-out-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][H5][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/partner-h5-payment/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/H5/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][H5][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/H5/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/create.html

--- a/src/Plugin/Wechat/V3/Pay/H5/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/H5/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/h5-payment/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][H5][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/ClosePlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/ClosePlugin.php
@@ -15,8 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/close-order.html
@@ -24,6 +24,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Jsapi][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/InvokePlugin.php
@@ -18,10 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/jsapi-transfer-payment.html
@@ -29,6 +27,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class InvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -53,7 +53,7 @@ class InvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $params, $config, $prepayId));
@@ -92,15 +92,15 @@ class InvokePlugin implements PluginInterface
             .$invokeConfig->get('nonceStr', '')."\n"
             .$invokeConfig->get('package', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config, array $params): string
     {
         if (Pay::MODE_SERVICE === ($config['mode'] ?? Pay::MODE_NORMAL)) {
-            return $payload?->get('_invoke_appid') ?? $config['sub_'.get_wechat_type_key($params)] ?? '';
+            return $payload?->get('_invoke_appid') ?? $config['sub_'.self::getWechatTypeKey($params)] ?? '';
         }
 
-        return $payload?->get('_invoke_appid') ?? $config[get_wechat_type_key($params)] ?? '';
+        return $payload?->get('_invoke_appid') ?? $config[self::getWechatTypeKey($params)] ?? '';
     }
 }

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/InvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/jsapi-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/PayPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/direct-jsons/jsapi-prepay.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -35,7 +36,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: Jsapi 下单，参数为空');
@@ -63,14 +64,14 @@ class PayPlugin implements PluginInterface
     protected function normal(array $config, array $params): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mchid' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $config, array $params): array
     {
-        $wechatTypeKey = get_wechat_type_key($params);
+        $wechatTypeKey = self::getWechatTypeKey($params);
 
         $data = [
             'sp_appid' => $config[$wechatTypeKey] ?? '',

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/PayPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/direct-jsons/jsapi-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryByWxPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-wx-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryByWxPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-wx-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Jsapi][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $transactionId = $payload?->get('transaction_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-out-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-out-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Jsapi][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/partner-jsapi-payment/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Jsapi][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Jsapi][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Jsapi/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Jsapi/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/jsapi-payment/create.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/ClosePlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/ClosePlugin.php
@@ -15,8 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/close-order.html
@@ -24,6 +24,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Mini][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Mini/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/InvokePlugin.php
@@ -18,9 +18,8 @@ use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_sign;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/mini-transfer-payment.html
@@ -28,6 +27,8 @@ use function Yansongda\Pay\get_wechat_sign;
  */
 class InvokePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -52,7 +53,7 @@ class InvokePlugin implements PluginInterface
         }
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $rocket->setDestination($this->getInvokeConfig($payload, $config, $prepayId));
@@ -91,7 +92,7 @@ class InvokePlugin implements PluginInterface
             .$invokeConfig->get('nonceStr', '')."\n"
             .$invokeConfig->get('package', '')."\n";
 
-        return get_wechat_sign($config, $contents);
+        return self::getWechatSign($config, $contents);
     }
 
     protected function getAppId(?Collection $payload, array $config): string

--- a/src/Plugin/Wechat/V3/Pay/Mini/InvokePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/InvokePlugin.php
@@ -15,11 +15,10 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
+use Yansongda\Pay\Traits\WechatTrait;
 use Yansongda\Supports\Collection;
 use Yansongda\Supports\Config;
 use Yansongda\Supports\Str;
-use Yansongda\Pay\Traits\WechatTrait;
-
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/mini-transfer-payment.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/PayPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/mini-prepay.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: Mini 下单，参数为空');

--- a/src/Plugin/Wechat/V3/Pay/Mini/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/PayPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/mini-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryByWxPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-wx-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Mini][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $transactionId = $payload?->get('transaction_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryByWxPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-wx-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-out-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-out-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Mini][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Mini][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Mini/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/partner-mini-program-payment/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/create.html

--- a/src/Plugin/Wechat/V3/Pay/Mini/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Mini/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/mini-program-payment/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][Pay][Mini][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Native/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/ClosePlugin.php
@@ -15,8 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/close-order.html
@@ -24,6 +24,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class ClosePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -34,7 +36,7 @@ class ClosePlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Native][ClosePlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Native/ClosePlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/ClosePlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/close-order.html

--- a/src/Plugin/Wechat/V3/Pay/Native/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/PayPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/direct-jsons/native-prepay.html

--- a/src/Plugin/Wechat/V3/Pay/Native/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/PayPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/direct-jsons/native-prepay.html
@@ -24,6 +23,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -35,7 +36,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: Native 下单，参数为空');
@@ -63,14 +64,14 @@ class PayPlugin implements PluginInterface
     protected function normal(array $params, array $config): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mchid' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $configKey = get_wechat_type_key($params);
+        $configKey = self::getWechatTypeKey($params);
 
         return [
             'sp_appid' => $config[$configKey] ?? '',

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryByWxPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-wx-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryByWxPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryByWxPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-wx-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryByWxPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -32,7 +34,7 @@ class QueryByWxPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Native][QueryByWxPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $transactionId = $payload?->get('transaction_id') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryPlugin.php
@@ -12,9 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-out-trade-no.html

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryPlugin.php
@@ -13,8 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-out-trade-no.html
@@ -22,6 +22,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -32,7 +34,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Native][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryRefundPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/partner-native-payment/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/Native/QueryRefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/QueryRefundPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryRefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryRefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Native][QueryRefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Native/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Native][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Native/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Native/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/native-payment/create.html

--- a/src/Plugin/Wechat/V3/Pay/Pos/CancelPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Pos/CancelPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/code-payment-v3/direct/reverse.html

--- a/src/Plugin/Wechat/V3/Pay/Pos/CancelPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Pos/CancelPlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/code-payment-v3/direct/reverse.html
@@ -25,6 +24,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class CancelPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -35,7 +36,7 @@ class CancelPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Pos][CancelPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         $outTradeNo = $payload?->get('out_trade_no') ?? null;
@@ -65,14 +66,14 @@ class CancelPlugin implements PluginInterface
     protected function normal(array $params, array $config): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mchid' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $configKey = get_wechat_type_key($params);
+        $configKey = self::getWechatTypeKey($params);
 
         return [
             'sp_appid' => $config[$configKey] ?? '',

--- a/src/Plugin/Wechat/V3/Pay/Pos/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Pos/PayPlugin.php
@@ -14,9 +14,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/code-payment-v3/direct/code-pay.html

--- a/src/Plugin/Wechat/V3/Pay/Pos/PayPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Pos/PayPlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_type_key;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/code-payment-v3/direct/code-pay.html
@@ -25,6 +24,8 @@ use function Yansongda\Pay\get_wechat_type_key;
  */
 class PayPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws ServiceNotFoundException
@@ -36,7 +37,7 @@ class PayPlugin implements PluginInterface
 
         $payload = $rocket->getPayload();
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
 
         if (is_null($payload)) {
             throw new InvalidParamsException(Exception::PARAMS_NECESSARY_PARAMS_MISSING, '参数异常: 付款码支付，参数为空');
@@ -63,14 +64,14 @@ class PayPlugin implements PluginInterface
     protected function normal(array $params, array $config): array
     {
         return [
-            'appid' => $config[get_wechat_type_key($params)] ?? '',
+            'appid' => $config[self::getWechatTypeKey($params)] ?? '',
             'mchid' => $config['mch_id'] ?? '',
         ];
     }
 
     protected function service(Collection $payload, array $params, array $config): array
     {
-        $configKey = get_wechat_type_key($params);
+        $configKey = self::getWechatTypeKey($params);
 
         return [
             'sp_appid' => $config[$configKey] ?? '',

--- a/src/Plugin/Wechat/V3/Pay/Refund/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/QueryPlugin.php
@@ -12,8 +12,8 @@ use Yansongda\Artful\Exception\ServiceNotFoundException;
 use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/query-by-out-refund-no.html
@@ -21,6 +21,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class QueryPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws InvalidParamsException
      * @throws ContainerException
@@ -31,7 +33,7 @@ class QueryPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Refund][QueryPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
         $outRefundNo = $payload?->get('out_refund_no') ?? null;
 

--- a/src/Plugin/Wechat/V3/Pay/Refund/QueryPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/QueryPlugin.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Traits\WechatTrait;
 
-
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/query-by-out-refund-no.html
  * @see https://pay.weixin.qq.com/docs/partner/apis/refund/refunds/query-by-out-refund-no.html

--- a/src/Plugin/Wechat/V3/Pay/Refund/RefundAbnormalPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/RefundAbnormalPlugin.php
@@ -16,11 +16,8 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\encrypt_wechat_contents;
-use function Yansongda\Pay\get_provider_config;
-use function Yansongda\Pay\get_wechat_public_key;
-use function Yansongda\Pay\get_wechat_serial_no;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/create-abnormal-refund.html
@@ -28,6 +25,8 @@ use function Yansongda\Pay\get_wechat_serial_no;
  */
 class RefundAbnormalPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws DecryptException
@@ -41,7 +40,7 @@ class RefundAbnormalPlugin implements PluginInterface
 
         $params = $rocket->getParams();
         $payload = $rocket->getPayload();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $refundId = $payload?->get('refund_id') ?? null;
 
         if (empty($refundId)) {
@@ -104,13 +103,13 @@ class RefundAbnormalPlugin implements PluginInterface
     protected function encryptSensitiveData(array $params, array $config, Collection $payload): array
     {
         if ($payload->has('bank_account') && $payload->has('real_name')) {
-            $data['_serial_no'] = get_wechat_serial_no($params);
+            $data['_serial_no'] = self::getWechatSerialNo($params);
 
-            $config = get_provider_config('wechat', $params);
-            $publicKey = get_wechat_public_key($config, $data['_serial_no']);
+            $config = self::getProviderConfig('wechat', $params);
+            $publicKey = self::getWechatPublicKey($config, $data['_serial_no']);
 
-            $data['real_name'] = encrypt_wechat_contents($payload->get('real_name'), $publicKey);
-            $data['bank_account'] = encrypt_wechat_contents($payload->get('bank_account'), $publicKey);
+            $data['real_name'] = self::encryptWechatContents($payload->get('real_name'), $publicKey);
+            $data['bank_account'] = self::encryptWechatContents($payload->get('bank_account'), $publicKey);
         }
 
         return $data ?? [];

--- a/src/Plugin/Wechat/V3/Pay/Refund/RefundAbnormalPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/RefundAbnormalPlugin.php
@@ -15,9 +15,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/create-abnormal-refund.html

--- a/src/Plugin/Wechat/V3/Pay/Refund/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/RefundPlugin.php
@@ -14,8 +14,8 @@ use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
 use Yansongda\Supports\Collection;
+use Yansongda\Pay\Traits\WechatTrait;
 
-use function Yansongda\Pay\get_provider_config;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/create.html
@@ -23,6 +23,8 @@ use function Yansongda\Pay\get_provider_config;
  */
 class RefundPlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidParamsException
@@ -33,7 +35,7 @@ class RefundPlugin implements PluginInterface
         Logger::debug('[Wechat][V3][Pay][Refund][RefundPlugin] 插件开始装载', ['rocket' => $rocket]);
 
         $params = $rocket->getParams();
-        $config = get_provider_config('wechat', $params);
+        $config = self::getProviderConfig('wechat', $params);
         $payload = $rocket->getPayload();
 
         if (is_null($payload)) {

--- a/src/Plugin/Wechat/V3/Pay/Refund/RefundPlugin.php
+++ b/src/Plugin/Wechat/V3/Pay/Refund/RefundPlugin.php
@@ -13,9 +13,8 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Pay;
-use Yansongda\Supports\Collection;
 use Yansongda\Pay\Traits\WechatTrait;
-
+use Yansongda\Supports\Collection;
 
 /**
  * @see https://pay.weixin.qq.com/docs/merchant/apis/refund/refunds/create.html

--- a/src/Plugin/Wechat/V3/VerifySignaturePlugin.php
+++ b/src/Plugin/Wechat/V3/VerifySignaturePlugin.php
@@ -14,9 +14,9 @@ use Yansongda\Artful\Logger;
 use Yansongda\Artful\Rocket;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\InvalidSignException;
+use Yansongda\Pay\Traits\WechatTrait;
 
 use function Yansongda\Artful\should_do_http_request;
-use Yansongda\Pay\Traits\WechatTrait;
 
 class VerifySignaturePlugin implements PluginInterface
 {

--- a/src/Plugin/Wechat/V3/VerifySignaturePlugin.php
+++ b/src/Plugin/Wechat/V3/VerifySignaturePlugin.php
@@ -16,10 +16,12 @@ use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\InvalidSignException;
 
 use function Yansongda\Artful\should_do_http_request;
-use function Yansongda\Pay\verify_wechat_sign;
+use Yansongda\Pay\Traits\WechatTrait;
 
 class VerifySignaturePlugin implements PluginInterface
 {
+    use WechatTrait;
+
     /**
      * @throws ContainerException
      * @throws InvalidConfigException
@@ -39,7 +41,7 @@ class VerifySignaturePlugin implements PluginInterface
             return $rocket;
         }
 
-        verify_wechat_sign($rocket->getDestinationOrigin(), $rocket->getParams());
+        self::verifyWechatSign($rocket->getDestinationOrigin(), $rocket->getParams());
 
         Logger::info('[Wechat][V3][VerifySignaturePlugin] 插件装载完毕', ['rocket' => $rocket]);
 


### PR DESCRIPTION
## Summary

v3.8.0 重构 PR 3 - Wechat Plugin 迁移使用 WechatTrait

### 迁移内容

- **Wechat V2/V3 plugins**: 105 个文件使用 WechatTrait

### 变更详情

- 添加 `use Yansongda\Pay\Traits\WechatTrait;`
- 在类中添加 `use WechatTrait;`
- 替换函数调用为 Trait 静态方法：
  - `get_provider_config('wechat', ...)` → `self::getProviderConfig('wechat', ...)`
  - `get_wechat_url(...)` → `self::getWechatUrl(...)`
  - `get_wechat_sign(...)` → `self::getWechatSign(...)`
  - `verify_wechat_sign(...)` → `self::verifyWechatSign(...)`
  - 等 19 个方法

### 保留项

- 所有 `@see` 注释完整保留
- 所有 PHPDoc `@throws` 注释完整保留
- 函数逻辑未做任何修改

### 前置依赖

- 基于 PR 1 已合并的 WechatTrait 基础设施
- 基于 PR 2 已合并的其他 Provider 迁移

### 后续 PR

- PR 4: 清理收尾（ServiceProvider继承修改、删除 Functions.php、更新 CHANGELOG）