### PR TITLE
fix: 修复 Trait 静态方法调用的 deprecation warnings

### DIFF
--- a/src/Traits/ProviderConfigTrait.php
+++ b/src/Traits/ProviderConfigTrait.php
@@ -26,7 +26,7 @@ trait ProviderConfigTrait
         /** @var ConfigInterface $config */
         $config = Pay::get(ConfigInterface::class);
 
-        return $config->get($provider, [])[self::getTenant($params)] ?? [];
+        return $config->get($provider, [])[static::getTenant($params)] ?? [];
     }
 
     public static function getRadarUrl(array $config, ?Collection $payload): ?string

--- a/src/Traits/StripeTrait.php
+++ b/src/Traits/StripeTrait.php
@@ -45,7 +45,7 @@ trait StripeTrait
      */
     public static function verifyStripeWebhookSign(ServerRequestInterface $request, array $params): void
     {
-        $config = self::getProviderConfig('stripe', $params);
+        $config = static::getProviderConfig('stripe', $params);
         $webhookSecret = $config['webhook_secret'] ?? null;
 
         if (empty($webhookSecret)) {

--- a/tests/Plugin/Stripe/V1/VerifyWebhookSignTest.php
+++ b/tests/Plugin/Stripe/V1/VerifyWebhookSignTest.php
@@ -11,6 +11,11 @@ use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\StripeTrait;
 
+class StripeTraitStub
+{
+    use StripeTrait;
+}
+
 class VerifyWebhookSignTest extends TestCase
 {
     public function testLocalhostNoLongerSkipsVerification()
@@ -20,7 +25,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 
     public function testMissingWebhookSecretThrowsException()
@@ -30,7 +35,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidConfigException::class);
         self::expectExceptionCode(Exception::CONFIG_STRIPE_INVALID);
 
-        StripeTrait::verifyStripeWebhookSign($request, ['_config' => 'no_webhook_secret']);
+        StripeTraitStub::verifyStripeWebhookSign($request, ['_config' => 'no_webhook_secret']);
     }
 
     public function testEmptySignatureHeaderThrowsException()
@@ -40,7 +45,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 
     public function testMalformedSignatureHeaderThrowsException()
@@ -52,7 +57,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 
     public function testExpiredTimestampThrowsException()
@@ -67,7 +72,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 
     public function testWrongSignatureThrowsException()
@@ -82,7 +87,7 @@ class VerifyWebhookSignTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
     }
 
     public function testValidSignaturePasses()
@@ -98,7 +103,7 @@ class VerifyWebhookSignTest extends TestCase
             'Stripe-Signature' => $signatureHeader,
         ], $body);
 
-        StripeTrait::verifyStripeWebhookSign($request, []);
+        StripeTraitStub::verifyStripeWebhookSign($request, []);
 
         self::assertTrue(true);
     }

--- a/tests/Traits/AlipayTraitTest.php
+++ b/tests/Traits/AlipayTraitTest.php
@@ -11,7 +11,6 @@ use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
 use Yansongda\Pay\Traits\AlipayTrait;
-use Yansongda\Pay\Traits\ProviderConfigTrait;
 use Yansongda\Supports\Collection;
 
 class AlipayTraitStub
@@ -23,10 +22,10 @@ class AlipayTraitTest extends TestCase
 {
     public function testVerifyAlipaySignSuccess(): void
     {
-        ProviderConfigTrait::getProviderConfig('alipay');
+        AlipayTraitStub::getProviderConfig('alipay');
         
         AlipayTraitStub::verifyAlipaySign(
-            ProviderConfigTrait::getProviderConfig('alipay'),
+            AlipayTraitStub::getProviderConfig('alipay'),
             json_encode([
                 "code" => "10000",
                 "msg" => "Success",
@@ -55,14 +54,14 @@ class AlipayTraitTest extends TestCase
 
         self::expectException(InvalidConfigException::class);
         self::expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
-        AlipayTraitStub::verifyAlipaySign(ProviderConfigTrait::getProviderConfig('alipay'), '', 'aaa');
+        AlipayTraitStub::verifyAlipaySign(AlipayTraitStub::getProviderConfig('alipay'), '', 'aaa');
     }
 
     public function testVerifyAlipaySignEmpty(): void
     {
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
-        AlipayTraitStub::verifyAlipaySign(ProviderConfigTrait::getProviderConfig('alipay'), '', '');
+        AlipayTraitStub::verifyAlipaySign(AlipayTraitStub::getProviderConfig('alipay'), '', '');
     }
 
     public function testGetAlipayUrlDefault(): void

--- a/tests/Traits/UnipayTraitTest.php
+++ b/tests/Traits/UnipayTraitTest.php
@@ -16,7 +16,6 @@ use Yansongda\Pay\Exception\Exception;
 use Yansongda\Pay\Exception\InvalidSignException;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
-use Yansongda\Pay\Traits\ProviderConfigTrait;
 use Yansongda\Pay\Traits\UnipayTrait;
 use Yansongda\Supports\Collection;
 
@@ -57,7 +56,7 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
 -----END CERTIFICATE-----&traceNo=067402&traceTime=0908132206&txnAmt=1&txnSubType=01&txnTime=20220908132206&txnType=01&version=5.1.0";
         $sign = 'JeA4S2+6TbGo9yjXDUvV5A2E3oJbunoCcZ66exN6xR3OH/5PNDK1VSV1Mq7XhVdxzkTeREUveiOYHalqoagRkh71nsHVvruwGbk6azygXSaawuO5tF67UIqNd4Mbufwh1KhbVpEkKbOETUvRhFcdon0fulE97I83eMSk52INHt8E1xk8NdbhyUadSlp+Uv30AKx70PpQbTGmVS3PJfd+Whj0b7LnvZKeC+BS1kUOtIKlcZO+gBoTigvCIJqj51kBrcBCs+x+VaeGm7EYBBhGSERpfQhQ4n+eJBwLdBeZ0/dNbo3iELjvVMx0n9KoW4klvUJhaH5LALA8pV02SbZv4Q==';
 
-        UnipayTraitStub::verifyUnipaySign(ProviderConfigTrait::getProviderConfig('unipay'), $contents, $sign);
+        UnipayTraitStub::verifyUnipaySign(UnipayTraitStub::getProviderConfig('unipay'), $contents, $sign);
 
         self::assertTrue(true);
 
@@ -99,7 +98,7 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
 
     public function testGetUnipaySignQra(): void
     {
-        $config = ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']);
+        $config = UnipayTraitStub::getProviderConfig('unipay', ['_config' => 'qra']);
 
         $payload = [
             'out_trade_no' => 'pos-qra-20240106163401',
@@ -144,7 +143,7 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
             "version" => "2.0",
         ];
 
-        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
+        UnipayTraitStub::verifyUnipaySignQra(UnipayTraitStub::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
         self::assertTrue(true);
 
         self::expectException(InvalidConfigException::class);
@@ -173,7 +172,7 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
+        UnipayTraitStub::verifyUnipaySignQra(UnipayTraitStub::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
     }
 
     public function testVerifyUnipaySignQraEmpty(): void
@@ -196,6 +195,6 @@ Q0C300Eo+XOoO4M1WvsRBAF13g9RPSw=\r
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
 
-        UnipayTraitStub::verifyUnipaySignQra(ProviderConfigTrait::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
+        UnipayTraitStub::verifyUnipaySignQra(UnipayTraitStub::getProviderConfig('unipay', ['_config' => 'qra']), $payload);
     }
 }

--- a/tests/Traits/WechatTraitTest.php
+++ b/tests/Traits/WechatTraitTest.php
@@ -73,7 +73,7 @@ class WechatTraitTest extends TestCase
 
         self::assertEquals(
             'KzIgMgiop3nQJNdBVR2Xah/JUwVBLDFFajyXPiSN8b8YAYEA4FuWfaCgFJ52+WFed+PhOYWx/ZPih4RaEuuSdYB8eZwYUx7RZGMQZk0bKCctAjjPuf4pJN+f/WsXKjPIy3diqF5x7gyxwSCaKWP4/KjsHNqgQpiC8q1uC5xmElzuhzSwj88LIoLtkAuSmtUVvdAt0Nz41ECHZgHWSGR32TfBo902r8afdaVKkFde8IoqcEJJcp6sMxdDO5l9R5KEWxrJ1SjsXVrb0IPH8Nj7e6hfhq7pucxojPpzsC+ZWAYvufZkAQx3kTiFmY87T+QhkP9FesOfWvkIRL4E6MP6ug==',
-            WechatTraitStub::getWechatSign(ProviderConfigTrait::getProviderConfig('wechat', []), $contents)
+            WechatTraitStub::getWechatSign(WechatTraitStub::getProviderConfig('wechat', []), $contents)
         );
 
         // test config error
@@ -94,7 +94,7 @@ class WechatTraitTest extends TestCase
     public function testGetWechatSignV2(): void
     {
         $params = ['name' => 'yansongda', 'age' => 29, 'foo' => ''];
-        self::assertEquals('3213848AED2C380749FD1D559555881D', WechatTraitStub::getWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat', $params), $params));
+        self::assertEquals('3213848AED2C380749FD1D559555881D', WechatTraitStub::getWechatSignV2(WechatTraitStub::getProviderConfig('wechat', $params), $params));
 
         // test config error
         $config1 = [
@@ -108,7 +108,7 @@ class WechatTraitTest extends TestCase
 
         self::expectException(InvalidConfigException::class);
         self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);
-        WechatTraitStub::getWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), []);
+        WechatTraitStub::getWechatSignV2(WechatTraitStub::getProviderConfig('wechat'), []);
     }
 
     public function testVerifyWechatSign(): void
@@ -144,13 +144,13 @@ class WechatTraitTest extends TestCase
     public function testVerifyWechatSignV2(): void
     {
         $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => '', 'sign' => '3213848AED2C380749FD1D559555881D'];
-        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+        WechatTraitStub::verifyWechatSignV2(WechatTraitStub::getProviderConfig('wechat'), $destination);
         self::assertTrue(true);
 
         $destination = ['name' => 'yansongda', 'age' => 29, 'foo' => ''];
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_EMPTY);
-        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+        WechatTraitStub::verifyWechatSignV2(WechatTraitStub::getProviderConfig('wechat'), $destination);
     }
 
     public function testVerifyWechatSignV2EmptySecret(): void
@@ -170,14 +170,14 @@ class WechatTraitTest extends TestCase
         self::expectException(InvalidSignException::class);
         self::expectExceptionCode(Exception::SIGN_ERROR);
 
-        WechatTraitStub::verifyWechatSignV2(ProviderConfigTrait::getProviderConfig('wechat'), $destination);
+        WechatTraitStub::verifyWechatSignV2(WechatTraitStub::getProviderConfig('wechat'), $destination);
     }
 
     public function testEncryptWechatContents(): void
     {
         $serialNo = '45F59D4DABF31918AFCEC556D5D2C6E376675D57';
         $contents = 'yansongda';
-        $result = WechatTraitStub::encryptWechatContents($contents, ProviderConfigTrait::getProviderConfig('wechat')['wechat_public_cert_path'][$serialNo]);
+        $result = WechatTraitStub::encryptWechatContents($contents, WechatTraitStub::getProviderConfig('wechat')['wechat_public_cert_path'][$serialNo]);
         self::assertIsString($result);
     }
 
@@ -185,7 +185,7 @@ class WechatTraitTest extends TestCase
     {
         $encrypted = 'WIesmK+dSJycwdhTTkNmv0Lk2wb9o7NGODovccjhyotNnRkEeh+sxRK1gNSRNMJJgkQ30m4HwcuweSO24mehFeXVNTVAKFVef/3FlHnYDZfE1c3mCLToEef7e8J/Z8TwFH1ecn3t+Jk9ZaBpQKNHdQ0Q8jcL7AnL48h0D9BcZxDekPqX6hNnKfISoKSv4TXFcgvBLFeAe4Q3KM0Snq0N5IvI86D9xZqVg6mY+Gfz0782ymQFxflau6Qxx3mJ+0etHMocNuCdgctVH390XYYMc0u+V2FCJ5cU5h/M/AxzP9ayrEO4l0ftaxL6lP0HjifNrkPcAAb+q9I67UepKO9iGw==';
 
-        $config = ProviderConfigTrait::getProviderConfig('wechat');
+        $config = WechatTraitStub::getProviderConfig('wechat');
 
         self::assertEquals('yansongda', WechatTraitStub::decryptWechatContents($encrypted, $config));
         self::assertNull(WechatTraitStub::decryptWechatContents('invalid', $config));
@@ -274,7 +274,7 @@ class WechatTraitTest extends TestCase
             'nonce' => '4196a5b75276',
         ];
 
-        $result = WechatTraitStub::decryptWechatResource($resource, ProviderConfigTrait::getProviderConfig('wechat'));
+        $result = WechatTraitStub::decryptWechatResource($resource, WechatTraitStub::getProviderConfig('wechat'));
 
         self::assertTrue(false !== strpos($result['ciphertext'], '-----BEGIN CERTIFICATE-----'));
     }
@@ -349,18 +349,18 @@ class WechatTraitTest extends TestCase
     public function testGetWechatPublicKey(): void
     {
         $serialNo = '45F59D4DABF31918AFCEC556D5D2C6E376675D57';
-        $result = WechatTraitStub::getWechatPublicKey(ProviderConfigTrait::getProviderConfig('wechat'), $serialNo);
+        $result = WechatTraitStub::getWechatPublicKey(WechatTraitStub::getProviderConfig('wechat'), $serialNo);
         self::assertIsString($result);
 
         $serialNo = 'non-exist';
         self::expectException(InvalidParamsException::class);
         self::expectExceptionCode(Exception::PARAMS_WECHAT_SERIAL_NOT_FOUND);
-        WechatTraitStub::getWechatPublicKey(ProviderConfigTrait::getProviderConfig('wechat'), $serialNo);
+        WechatTraitStub::getWechatPublicKey(WechatTraitStub::getProviderConfig('wechat'), $serialNo);
     }
 
     public function testGetWechatMiniprogramPaySign(): void
     {
-        self::assertEquals('6bb3e49bb4744fc6817331333ffa435e0d1409c3c900a87637c98265445cbe96', WechatTraitStub::getWechatMiniprogramPaySign(ProviderConfigTrait::getProviderConfig('wechat'), 'yansongda.cn', '{"name":"yansongda"}'));
+        self::assertEquals('6bb3e49bb4744fc6817331333ffa435e0d1409c3c900a87637c98265445cbe96', WechatTraitStub::getWechatMiniprogramPaySign(WechatTraitStub::getProviderConfig('wechat'), 'yansongda.cn', '{"name":"yansongda"}'));
 
         self::expectException(InvalidConfigException::class);
         self::expectExceptionCode(Exception::CONFIG_WECHAT_INVALID);


### PR DESCRIPTION
## Summary

修复 PHPUnit 测试中的 31 个 deprecation warnings

### 问题

PHP 8.0+ 不允许直接通过 trait 名称调用静态方法，必须通过使用该 trait 的类来调用。

### 修复内容

1. **测试文件**：通过 Stub 类调用 Trait 方法
   - `WechatTraitTest.php`: `ProviderConfigTrait::getProviderConfig()` → `WechatTraitStub::getProviderConfig()`
   - `AlipayTraitTest.php`: `ProviderConfigTrait::getProviderConfig()` → `AlipayTraitStub::getProviderConfig()`
   - `UnipayTraitTest.php`: `ProviderConfigTrait::getProviderConfig()` → `UnipayTraitStub::getProviderConfig()`
   - `VerifyWebhookSignTest.php`: 新增 `StripeTraitStub` 类

2. **Trait 内部调用**：使用 `static::` 代替 `self::`
   - `ProviderConfigTrait.php:29`: `self::getTenant()` → `static::getTenant()`
   - `StripeTrait.php:48`: `self::getProviderConfig()` → `static::getProviderConfig()`

3. **删除未使用的 import**

### 验证结果

- PHPUnit: ✅ 1070 tests, 2438 assertions, 0 deprecations
- PHPStan: ✅ No errors
- CS-Fixer: ✅ 0 files to fix