### PR TITLE
fix: 更新 Scrutinizer 镜像以支持 PHP 8.2

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,8 +6,12 @@ checks:
     php: true
 
 build:
+    image: default-bionic
     nodes:
         analysis:
+            environment:
+                php:
+                    version: 8.2.15
             tests:
                 override:
                     - php-scrutinizer-run


### PR DESCRIPTION
## Summary

- 将 Scrutinizer 构建镜像切换为 `default-bionic`，避免旧环境中 OpenSSL 1.0.1f 导致 PHP 8.2 编译失败
- 在 `.scrutinizer.yml` 中显式指定 `php.version: 8.2.15`
- 保持现有 `php-scrutinizer-run` 分析流程不变，只修复 CI 环境问题

## Root Cause

Scrutinizer 默认镜像中的 OpenSSL 版本过旧，日志中显示：

```text
Requested 'openssl >= 1.0.2' but version of OpenSSL is 1.0.1f
```

这会导致平台在构建 PHP 8.2.0 时于 `configure` 阶段失败。

## Expected Result

- Scrutinizer 不再因 OpenSSL 版本不足而中止 PHP 8.2 构建
- CI 能正常进入 `php-scrutinizer-run` 分析阶段