### PR TITLE
fix: 修正 Config.php 错误码误用 & Pay::config() 去重

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -55,13 +55,13 @@ class Config extends BaseConfig
     public function getProviderConfig(string $provider, ?string $tenant = null): ProviderConfigInterface
     {
         if (!isset(self::PROVIDER_CONFIG_MAP[$provider])) {
-            throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, "Unknown provider: {$provider}");
+            throw new InvalidConfigException(Exception::CONFIG_PROVIDER_INVALID, "配置异常: 未知的 Provider - {$provider}");
         }
 
         $tenant = $tenant ?? 'default';
 
         if (!isset($this->items[$provider][$tenant])) {
-            throw new InvalidConfigException(Exception::CONFIG_ALIPAY_INVALID, "Config for {$provider}.{$tenant} not found");
+            throw new InvalidConfigException(Exception::CONFIG_PROVIDER_INVALID, "配置异常: {$provider}.{$tenant} 配置不存在");
         }
 
         return $this->items[$provider][$tenant];

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -71,7 +71,9 @@ class Exception extends \Exception
 
     public const CONFIG_STRIPE_INVALID = 9407;
 
-    public const CONFIG_CERT_PARSE_FAILED = 9408;
+    public const CONFIG_PROVIDER_INVALID = 9408;
+
+    public const CONFIG_CERT_PARSE_FAILED = 9409;
 
     /**
      * 关于签名.

--- a/src/Pay.php
+++ b/src/Pay.php
@@ -94,32 +94,14 @@ class Pay
      */
     public static function config(array|Config $config = [], Closure|ContainerInterface|null $container = null): bool
     {
-        // Early return check for array input (avoid validation for partial configs)
-        // Only return false if already configured (ConfigInterface bound) and not forced
-        if (is_array($config) && !($config['_force'] ?? false)) {
-            try {
-                if (Artful::has(ConfigInterface::class)) {
-                    return false;
-                }
-            } catch (ContainerException) {
-                // Container not found, proceed with config
-            }
+        $force = is_array($config) && ($config['_force'] ?? false);
+
+        if (!$force && self::isAlreadyConfigured()) {
+            return false;
         }
 
         $configObject = is_array($config) ? new Config($config) : $config;
         $runtimeConfig = $configObject->all();
-        $force = is_array($config) ? (bool) ($config['_force'] ?? false) : (bool) ($runtimeConfig['_force'] ?? false);
-
-        // For Config instance input, check force from runtime config
-        if (!is_array($config) && !$force) {
-            try {
-                if (Artful::has(ConfigInterface::class)) {
-                    return false;
-                }
-            } catch (ContainerException) {
-                // Container not found, proceed with config
-            }
-        }
 
         // Force Artful::config() to execute by setting _force in runtime config
         $runtimeConfig['_force'] = true;
@@ -138,6 +120,20 @@ class Pay
         }
 
         return $result;
+    }
+
+    /**
+     * 检查是否已经配置过.
+     *
+     * @throws ContainerException
+     */
+    private static function isAlreadyConfigured(): bool
+    {
+        try {
+            return Artful::has(ConfigInterface::class);
+        } catch (ContainerException) {
+            return false;
+        }
     }
 
     /**

--- a/src/Pay.php
+++ b/src/Pay.php
@@ -123,20 +123,6 @@ class Pay
     }
 
     /**
-     * 检查是否已经配置过.
-     *
-     * @throws ContainerException
-     */
-    private static function isAlreadyConfigured(): bool
-    {
-        try {
-            return Artful::has(ConfigInterface::class);
-        } catch (ContainerException) {
-            return false;
-        }
-    }
-
-    /**
      * @throws ContainerException
      */
     public static function set(string $name, mixed $value): void
@@ -161,5 +147,14 @@ class Pay
     public static function clear(): void
     {
         Artful::clear();
+    }
+
+    private static function isAlreadyConfigured(): bool
+    {
+        try {
+            return Artful::has(ConfigInterface::class);
+        } catch (ContainerException) {
+            return false;
+        }
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -77,8 +77,8 @@ class ConfigTest extends TestCase
         $config = new Config([]);
 
         $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
-        $this->expectExceptionMessage('Unknown provider: unknown');
+        $this->expectExceptionCode(Exception::CONFIG_PROVIDER_INVALID);
+        $this->expectExceptionMessage('配置异常: 未知的 Provider - unknown');
 
         $config->getProviderConfig('unknown');
     }
@@ -98,8 +98,8 @@ class ConfigTest extends TestCase
         ]);
 
         $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionCode(Exception::CONFIG_ALIPAY_INVALID);
-        $this->expectExceptionMessage('Config for alipay.missing_tenant not found');
+        $this->expectExceptionCode(Exception::CONFIG_PROVIDER_INVALID);
+        $this->expectExceptionMessage('配置异常: alipay.missing_tenant 配置不存在');
 
         $config->getProviderConfig('alipay', 'missing_tenant');
     }


### PR DESCRIPTION
## Summary

- **修正错误码误用**：`Config::getProviderConfig()` 在 provider 不存在或租户配置缺失时，错误地使用了 `Exception::CONFIG_ALIPAY_INVALID`（9401）。新增 `Exception::CONFIG_PROVIDER_INVALID`（9408），替换两处误用，错误消息统一为中文
- **Pay::config() 去重**：提取重复的「检查是否已配置」逻辑为 `isAlreadyConfigured()` 私有方法，消除两段近乎相同的 try/catch 代码

## 变更详情

| 文件 | 变更 |
|------|------|
| `src/Exception/Exception.php` | 新增 `CONFIG_PROVIDER_INVALID = 9408`；`CONFIG_CERT_PARSE_FAILED` 从 9408 调整为 9409 |
| `src/Config.php` | 两处 `CONFIG_ALIPAY_INVALID` → `CONFIG_PROVIDER_INVALID`，错误消息改为中文 |
| `src/Pay.php` | 提取 `isAlreadyConfigured()` 方法，简化 `config()` 逻辑 |
| `tests/Config/ConfigTest.php` | 更新期望的错误码和消息 |

## 测试

`ConfigTest`（61 tests）和 `PayTest + StartPluginTest`（59 tests）全部通过。