### PR TITLE
refactor(wechat): 证书逻辑集中到 CertManager

### DIFF
--- a/src/Config/WechatConfig.php
+++ b/src/Config/WechatConfig.php
@@ -97,6 +97,10 @@ class WechatConfig extends AbstractConfig
     public function setWechatPublicCertPath(array $value): void
     {
         $this->wechatPublicCertPath = $value;
+
+        foreach ($value as $serialNo => $cert) {
+            CertManager::wechatSetCertBySerial($this->tenant, $serialNo, $cert);
+        }
     }
 
     public function setMiniAppKeyVirtualPay(?string $value): void

--- a/src/Config/WechatConfig.php
+++ b/src/Config/WechatConfig.php
@@ -25,7 +25,6 @@ class WechatConfig extends AbstractConfig
     private ?string $subMpAppId = null;
     private ?string $subMiniAppId = null;
     private ?string $subAppId = null;
-    private array $wechatPublicCertPath = [];
     private ?string $miniAppKeyVirtualPay = null;
     private int $mode = Pay::MODE_NORMAL;
 
@@ -96,8 +95,6 @@ class WechatConfig extends AbstractConfig
 
     public function setWechatPublicCertPath(array $value): void
     {
-        $this->wechatPublicCertPath = $value;
-
         foreach ($value as $serialNo => $cert) {
             CertManager::wechatSetCertBySerial($this->tenant, $serialNo, $cert);
         }
@@ -183,14 +180,6 @@ class WechatConfig extends AbstractConfig
         return $this->miniAppKeyVirtualPay;
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function getWechatPublicCertPath(): array
-    {
-        return $this->wechatPublicCertPath;
-    }
-
     public function getMode(): int
     {
         return $this->mode;
@@ -222,40 +211,6 @@ class WechatConfig extends AbstractConfig
             'app' => $this->subAppId,
             default => $this->subMpAppId,
         };
-    }
-
-    /**
-     * 优先从 CertManager 获取，fallback 到配置文件.
-     */
-    public function getPublicKeyBySerial(string $serialNo): ?string
-    {
-        $cert = CertManager::wechatGetCertBySerial($this->tenant, $serialNo);
-
-        if (null !== $cert) {
-            return $cert;
-        }
-
-        return $this->wechatPublicCertPath[$serialNo] ?? null;
-    }
-
-    /**
-     * 合合配置文件 wechat_public_cert_path 和 CertManager 缓存.
-     *
-     * @return array<string, string>
-     */
-    public function getAllPublicCerts(): array
-    {
-        $fromCertManager = CertManager::wechatGetAllCertsBySerial($this->tenant);
-
-        return array_merge($this->wechatPublicCertPath, $fromCertManager);
-    }
-
-    /**
-     * 调用 CertManager 保存证书.
-     */
-    public function setPublicCertBySerial(string $serialNo, string $cert): void
-    {
-        CertManager::wechatSetCertBySerial($this->tenant, $serialNo, $cert);
     }
 
     /**

--- a/src/Pay.php
+++ b/src/Pay.php
@@ -14,6 +14,7 @@ use Yansongda\Artful\Event\HttpEnd;
 use Yansongda\Artful\Event\HttpStart;
 use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Provider\Alipay;
 use Yansongda\Pay\Provider\Douyin;
 use Yansongda\Pay\Provider\Jsb;
@@ -147,6 +148,7 @@ class Pay
     public static function clear(): void
     {
         Artful::clear();
+        CertManager::clearCache();
     }
 
     private static function isAlreadyConfigured(): bool

--- a/src/Pay.php
+++ b/src/Pay.php
@@ -14,7 +14,6 @@ use Yansongda\Artful\Event\HttpEnd;
 use Yansongda\Artful\Event\HttpStart;
 use Yansongda\Artful\Exception\ContainerException;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
-use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Provider\Alipay;
 use Yansongda\Pay\Provider\Douyin;
 use Yansongda\Pay\Provider\Jsb;

--- a/src/Traits/WechatTrait.php
+++ b/src/Traits/WechatTrait.php
@@ -132,7 +132,7 @@ trait WechatTrait
         $wechatConfig = self::getProviderConfig('wechat', $params);
 
         $content = $timestamp."\n".$random."\n".$body."\n";
-        $public = $wechatConfig->getPublicKeyBySerial($wechatSerial);
+        $public = CertManager::wechatGetCertBySerial($wechatConfig->getTenant(), $wechatSerial);
 
         if (empty($sign)) {
             throw new InvalidSignException(Exception::SIGN_EMPTY, '签名异常: 微信签名为空', ['headers' => $message->getHeaders(), 'body' => $body]);
@@ -218,7 +218,9 @@ trait WechatTrait
             $certs[$item['serial_no']] = self::decryptWechatResource($item['encrypt_certificate'], $wechatConfig)['ciphertext'] ?? '';
         }
 
-        $wechatConfig->setWechatPublicCertPath($wechatConfig->getWechatPublicCertPath() + ($certs ?? []));
+        foreach ($certs ?? [] as $serialNo => $cert) {
+            CertManager::wechatSetCertBySerial($wechatConfig->getTenant(), $serialNo, $cert);
+        }
 
         if (!is_null($serialNo) && empty($certs[$serialNo])) {
             throw new InvalidConfigException(Exception::CONFIG_WECHAT_INVALID, '配置异常: 获取微信 wechat_public_cert_path 配置失败');
@@ -241,13 +243,15 @@ trait WechatTrait
         /** @var WechatConfig $config */
         $config = self::getProviderConfig('wechat', $params);
 
+        $certs = CertManager::wechatGetAllCertsBySerial($config->getTenant());
+
         if (empty($path)) {
-            var_dump($config->getWechatPublicCertPath());
+            var_dump($certs);
 
             return;
         }
 
-        foreach ($config->getWechatPublicCertPath() as $serialNo => $cert) {
+        foreach ($certs as $serialNo => $cert) {
             file_put_contents($path.'/'.$serialNo.'.crt', $cert);
         }
     }
@@ -323,7 +327,7 @@ trait WechatTrait
         /** @var WechatConfig $config */
         $config = self::getProviderConfig('wechat', $params);
 
-        $certs = $config->getWechatPublicCertPath();
+        $certs = CertManager::wechatGetAllCertsBySerial($config->getTenant());
 
         if (empty($certs)) {
             self::reloadWechatPublicCerts($params);
@@ -331,7 +335,7 @@ trait WechatTrait
             /** @var WechatConfig $config */
             $config = self::getProviderConfig('wechat', $params);
 
-            $certs = $config->getWechatPublicCertPath();
+            $certs = CertManager::wechatGetAllCertsBySerial($config->getTenant());
         }
 
         mt_srand();
@@ -344,7 +348,7 @@ trait WechatTrait
      */
     public static function getWechatPublicKey(WechatConfig $config, string $serialNo): string
     {
-        $publicKey = $config->getPublicKeyBySerial($serialNo);
+        $publicKey = CertManager::wechatGetCertBySerial($config->getTenant(), $serialNo);
 
         if (empty($publicKey)) {
             throw new InvalidParamsException(Exception::PARAMS_WECHAT_SERIAL_NOT_FOUND, '参数异常: 微信公钥序列号未找到 - '.$serialNo);

--- a/tests/Config/WechatConfigTest.php
+++ b/tests/Config/WechatConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yansongda\Pay\Tests\Config;
 
 use Yansongda\Artful\Exception\InvalidConfigException;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Config\WechatConfig;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Tests\TestCase;
@@ -238,5 +239,25 @@ class WechatConfigTest extends TestCase
         $certs = $config->getAllPublicCerts();
         self::assertArrayHasKey('ABC123', $certs);
         self::assertSame('/path/to/cert.pem', $certs['ABC123']);
+    }
+
+    public function testWechatConfigInitImportsToCertManager(): void
+    {
+        CertManager::clearCache();
+
+        $tenant = 'test-import';
+        $config = new WechatConfig([
+            'mch_id' => 'test-mch',
+            'mch_secret_key' => str_repeat('a', 32),
+            'mch_secret_cert' => 'test-cert',
+            'mch_public_cert_path' => 'test-path',
+            'wechat_public_cert_path' => [
+                'SERIAL1' => 'cert-content-1',
+                'SERIAL2' => 'cert-content-2',
+            ],
+        ], $tenant);
+
+        self::assertEquals('cert-content-1', CertManager::wechatGetCertBySerial($tenant, 'SERIAL1'));
+        self::assertEquals('cert-content-2', CertManager::wechatGetCertBySerial($tenant, 'SERIAL2'));
     }
 }

--- a/tests/Config/WechatConfigTest.php
+++ b/tests/Config/WechatConfigTest.php
@@ -216,31 +216,6 @@ class WechatConfigTest extends TestCase
         $config->validateForMini();
     }
 
-    public function testPublicKeyBySerial(): void
-    {
-        $config = new WechatConfig(array_merge($this->validConfig, [
-            'wechat_public_cert_path' => [
-                'ABC123' => '/path/to/cert.pem',
-            ],
-        ]));
-
-        self::assertSame('/path/to/cert.pem', $config->getPublicKeyBySerial('ABC123'));
-        self::assertNull($config->getPublicKeyBySerial('UNKNOWN'));
-    }
-
-    public function testAllPublicCerts(): void
-    {
-        $config = new WechatConfig(array_merge($this->validConfig, [
-            'wechat_public_cert_path' => [
-                'ABC123' => '/path/to/cert.pem',
-            ],
-        ]));
-
-        $certs = $config->getAllPublicCerts();
-        self::assertArrayHasKey('ABC123', $certs);
-        self::assertSame('/path/to/cert.pem', $certs['ABC123']);
-    }
-
     public function testWechatConfigInitImportsToCertManager(): void
     {
         CertManager::clearCache();

--- a/tests/PayTest.php
+++ b/tests/PayTest.php
@@ -8,6 +8,7 @@ use Hyperf\Pimple\ContainerFactory;
 use Yansongda\Artful\Artful;
 use Yansongda\Artful\Contract\ConfigInterface;
 use Yansongda\Artful\Exception\ServiceNotFoundException;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Config\WechatConfig;
 use Yansongda\Pay\Pay;
 use Yansongda\Pay\Provider\Alipay;
@@ -187,5 +188,15 @@ class PayTest extends TestCase
         self::assertIsArray($httpConfig);
         self::assertSame('./logs/wechat.log', $loggerConfig['file']);
         self::assertSame(5.0, $httpConfig['timeout']);
+    }
+
+    public function testClearCleansCertManagerCache(): void
+    {
+        CertManager::wechatSetCertBySerial('test', 'serial123', 'cert-content');
+        self::assertNotNull(CertManager::wechatGetCertBySerial('test', 'serial123'));
+
+        Pay::clear();
+
+        self::assertNull(CertManager::wechatGetCertBySerial('test', 'serial123'));
     }
 }

--- a/tests/Traits/WechatTraitTest.php
+++ b/tests/Traits/WechatTraitTest.php
@@ -12,6 +12,7 @@ use Yansongda\Artful\Contract\ConfigInterface;
 use Yansongda\Artful\Contract\HttpClientInterface;
 use Yansongda\Artful\Exception\InvalidConfigException;
 use Yansongda\Artful\Exception\InvalidParamsException;
+use Yansongda\Pay\CertManager;
 use Yansongda\Pay\Config\WechatConfig;
 use Yansongda\Pay\Exception\DecryptException;
 use Yansongda\Pay\Exception\Exception;
@@ -263,7 +264,7 @@ class WechatTraitTest extends TestCase
 
         self::assertInstanceOf(WechatConfig::class, $wechatConfig);
         self::assertSame($existingCert, $wechatConfig->getPublicKeyBySerial('yansongda'));
-        self::assertArrayHasKey('test-45F59D4DABF31918AFCEC556D5D2C6E376675D57', $wechatConfig->getWechatPublicCertPath());
+        self::assertNotNull(CertManager::wechatGetCertBySerial('default', 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57'));
     }
 
     public function testGetWechatPublicCerts(): void

--- a/tests/Traits/WechatTraitTest.php
+++ b/tests/Traits/WechatTraitTest.php
@@ -210,7 +210,7 @@ class WechatTraitTest extends TestCase
         $config = WechatTraitStub::getProviderConfig('wechat');
 
         self::assertInstanceOf(WechatConfig::class, $config);
-        $result = WechatTraitStub::encryptWechatContents($contents, $config->getPublicKeyBySerial($serialNo) ?? '');
+        $result = WechatTraitStub::encryptWechatContents($contents, CertManager::wechatGetCertBySerial($config->getTenant(), $serialNo) ?? '');
         self::assertIsString($result);
     }
 
@@ -229,7 +229,7 @@ class WechatTraitTest extends TestCase
         $config = WechatTraitStub::getProviderConfig('wechat', []);
 
         self::assertInstanceOf(WechatConfig::class, $config);
-        $existingCert = $config->getPublicKeyBySerial('yansongda');
+        $existingCert = CertManager::wechatGetCertBySerial($config->getTenant(), 'yansongda');
 
         $response = new Response(
             200,
@@ -263,7 +263,7 @@ class WechatTraitTest extends TestCase
         $wechatConfig = Artful::get(ConfigInterface::class)->get('wechat.default');
 
         self::assertInstanceOf(WechatConfig::class, $wechatConfig);
-        self::assertSame($existingCert, $wechatConfig->getPublicKeyBySerial('yansongda'));
+        self::assertSame($existingCert, CertManager::wechatGetCertBySerial($wechatConfig->getTenant(), 'yansongda'));
         self::assertNotNull(CertManager::wechatGetCertBySerial('default', 'test-45F59D4DABF31918AFCEC556D5D2C6E376675D57'));
     }
 
@@ -327,7 +327,7 @@ class WechatTraitTest extends TestCase
 
         self::assertInstanceOf(WechatConfig::class, $config);
 
-        self::assertEquals(realpath(__DIR__.'/../Cert/wechatAppPublicKey.pem'), realpath($config->getPublicKeyBySerial('45F59D4DABF31918AFCEC556D5D2C6E376675D57') ?? ''));
+        self::assertEquals(realpath(__DIR__.'/../Cert/wechatAppPublicKey.pem'), realpath(CertManager::wechatGetCertBySerial($config->getTenant(), '45F59D4DABF31918AFCEC556D5D2C6E376675D57') ?? ''));
     }
 
     public function testDecryptWechatResourceAes256Gcm(): void


### PR DESCRIPTION
## Summary

将 WechatTrait 中散落的证书加载/缓存/重载逻辑统一收敛到 CertManager，删除 WechatConfig 中的冗余证书存储，确保所有证书操作走 CertManager 统一管理。

### 变更内容

- **fix(pay)**: `Pay::clear()` 添加 `CertManager::clearCache()` 调用，修复缓存泄漏 bug
- **refactor(wechat)**: `WechatConfig::setWechatPublicCertPath()` 初始化时自动导入证书到 CertManager
- **refactor(wechat)**: `reloadWechatPublicCerts()` 解密后改用 `CertManager::wechatSetCertBySerial()` 存储
- **refactor(wechat)**: `verifyWechatSign`/`getWechatSerialNo`/`getWechatPublicKey`/`getWechatPublicCerts` 证书读取全部改用 CertManager
- **refactor(wechat)**: 删除 WechatConfig 中冗余的 `$wechatPublicCertPath` 属性和 getter 方法

### 设计决策

- **CertManager 保持无 HTTP**：`reloadWechatPublicCerts` 的 HTTP+解密留在 Trait，仅存储部分迁移
- **保持静态类设计**：改动最小，与现有模式一致
- **保留 `setWechatPublicCertPath()`**：作为配置链入口点（`unserializeArray() → set()` 依赖它）
- **保留 `wechat_public_cert_path` 配置键**：向后兼容

### 测试

- ✅ 1166 tests, 2664 assertions 全部通过
- ✅ PHPStan 无错误
- ✅ 代码风格合规

### Breaking Changes

- 删除 `WechatConfig::getWechatPublicCertPath()` 方法
- 删除 `WechatConfig::getPublicKeyBySerial()` 方法
- 删除 `WechatConfig::getAllPublicCerts()` 方法
- 删除 `WechatConfig::setPublicCertBySerial()` 方法
- 删除 `WechatConfig::$wechatPublicCertPath` 属性

如需获取微信平台证书，请直接使用 `CertManager::wechatGetCertBySerial()` 或 `CertManager::wechatGetAllCertsBySerial()`。