### PR TITLE
refactor: 提取开发规范到 dev-guide Skill

### DIFF
--- a/.agents/skills/dev-guide/SKILL.md
+++ b/.agents/skills/dev-guide/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dev-guide
+description: Use when developing, testing, or adding new providers to yansongda/pay project. Covers commands, code standards, and provider implementation guide.
+---
+
+# yansongda/pay 开发指南
+
+## 开发命令
+
+**对 `src/` PHP 代码的任何修改，需运行以下三项检查：**
+
+```bash
+composer cs-fix && composer analyse && composer test
+```
+
+### 测试
+```bash
+composer test       # PHPUnit 11.x + Mockery 1.6
+```
+- 测试前需安装 `hyperf/pimple`
+- Mock HTTP 客户端避免真实请求
+
+### 代码风格
+```bash
+composer cs-fix     # 代码格式化检查（dry-run）
+```
+
+### 静态分析
+```bash
+composer analyse    # PHPStan
+```
+
+### 文档
+```bash
+cd web && pnpm web:dev    # 文档开发
+cd web && pnpm web:build  # 文档构建
+cd web && pnpm web:serve  # 本地预览
+```
+
+### 本地开发环境
+优先本地 PHP 环境；若无 PHP，使用 Container 作为备选，详见 `container-dev` Skill。
+
+### CI 矩阵
+PHP 8.2-8.5 + Laravel/Hyperf/Default
+
+---
+
+## 代码规范
+
+- `declare(strict_types=1);` 必须
+- `use` 导入，禁止 `\Yansongda\Pay\...`
+- 日志/异常消息用中文
+- 命名：`{Action}Plugin.php`、`{Action}Shortcut.php`、`{Provider}Trait.php`
+
+---
+
+## 新增 Provider 流程
+
+### 6 阶段
+1. **配置**：`src/Config/{Provider}Config.php`
+2. **核心类**：`src/Provider/{Provider}.php` + `src/Service/{Provider}ServiceProvider.php`（继承 AbstractServiceProvider）
+3. **插件**：`src/Plugin/{Provider}/V{n}/`（含 CallbackPlugin）
+4. **快捷方式**：`src/Shortcut/{Provider}/{Action}Shortcut.php`
+5. **Trait**：`src/Traits/{Provider}Trait.php`（`get{Provider}Url`、`verify{Provider}Sign`）
+6. **注册**：`Pay.php` + `Config.php` 映射 + `Exception.php` 常量 + 测试 + 文档
+
+---
+
+## 常见错误
+
+- 忽略 `declare(strict_types=1);`
+- 直接写完整命名空间
+- 回调未验签
+- 测试未 Mock HTTP 客户端

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,17 +31,8 @@ src/
 - **安全第一**：回调/Webhook 必须验签，禁止直接信任传入数据
 - **代码一致性**：新增 Provider 遵循现有结构
 
-## COMMANDS
-```
-composer test       # PHPUnit 11.x + Mockery 1.6 测试前需安装 `hyperf/pimple`
-composer cs-fix     # 代码格式化检查（dry-run）
-composer analyse    # PHPStan
-
-cd web && pnpm web:dev   # 文档开发
-cd web && pnpm web:build # 文档构建
-```
-- **本地开发环境**：优先本地 PHP 环境；若无 PHP，使用 Container 作为备选，详见 `.agents/skills/container-dev/SKILL.md`
-- **CI 矩阵**：PHP 8.2-8.5 + Laravel/Hyperf/Default
+## COMMANDS & 开发规范
+详见 `.agents/skills/dev-guide/SKILL.md`，使用时加载。
 
 ## 架构要点
 - **插件管道**：`StartPlugin → [前置] → 业务插件 → [后置] → ParserPlugin`
@@ -75,22 +66,3 @@ cd web && pnpm web:build # 文档构建
 
 > 完整方法列表见 `src/Traits/{Provider}Trait.php`
 
-## 新增 Provider（6 阶段）
-1. **配置**：`src/Config/{Provider}Config.php`
-2. **核心类**：`src/Provider/{Provider}.php` + `src/Service/{Provider}ServiceProvider.php`（继承 AbstractServiceProvider）
-3. **插件**：`src/Plugin/{Provider}/V{n}/`（含 CallbackPlugin）
-4. **快捷方式**：`src/Shortcut/{Provider}/{Action}Shortcut.php`
-5. **Trait**：`src/Traits/{Provider}Trait.php`（`get{Provider}Url`、`verify{Provider}Sign`）
-6. **注册**：`Pay.php` + `Config.php` 映射 + `Exception.php` 常量 + 测试 + 文档
-
-## 代码规范
-- `declare(strict_types=1);` 必须
-- `use` 导入，禁止 `\Yansongda\Pay\...`
-- 日志/异常消息用中文
-- 命名：`{Action}Plugin.php`、`{Action}Shortcut.php`、`{Provider}Trait.php`
-
-## 常见错误
-- 忽略 `declare(strict_types=1);`
-- 直接写完整命名空间
-- 回调未验签
-- 测试未 Mock HTTP 客户端


### PR DESCRIPTION
## Summary

- 将 COMMANDS、代码规范、新增 Provider 流程、常见错误从 AGENTS.md 移至独立的 Skill 文件
- AGENTS.md 简化为引用 dev-guide Skill，保持核心文档精简
- 添加 `src/` 代码修改需运行三项检查（cs-fix、analyse、test）的明确要求

## Changes

### 新增
- `.agents/skills/dev-guide/SKILL.md`：开发命令、代码规范、新增 Provider 流程、常见错误

### 修改
- `AGENTS.md`：简化 COMMANDS 部分，删除已迁移的内容

## Motivation

- AGENTS.md 聚焦于"始终需要"的核心信息（项目概述、架构、组件、签名验证）
- 开发相关规范按需加载，减少文档冗余
- 符合现有 Skill 使用模式（已引用 container-dev Skill）