### PR TITLE
docs: update CHANGELOG and upgrade guide for v3.8.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+
+## v3.8.0-beta.2 - 2026-07-01
+
 ### Added
 
 - 新增微信小程序虚拟支付支持 (#1172)

--- a/web/docs/v3/upgrade/v3.8.md
+++ b/web/docs/v3/upgrade/v3.8.md
@@ -11,6 +11,7 @@
 ### 简单使用者
 
 - 检查是否有使用微信 `MchTransfer` 相关插件，命名空间已变更为 `Transfer`
+- v3.8.0-beta.2 起新增微信小程序虚拟支付支持，如需使用请在 `wechat.default` 配置中增加 `virtual_pay` 节点（offer_id、app_key、callback_token 等）
 
 ### 自有插件开发者
 


### PR DESCRIPTION
## v3.8.0-beta.2 - 2026-07-01

### Added

- 新增微信小程序虚拟支付支持 (#1172)
  - 新增 `WechatConfigVirtualPay` 配置类（appKey、sandboxAppKey、offerId、encodingAesKey、callbackToken）
  - 新增虚拟支付插件：PayPlugin、CallbackPlugin、AddPayloadSignaturePlugin、VerifySignaturePlugin
  - 新增业务插件：Currency（代币）、Goods（商品）、Order（订单）、Subscribe（订阅）、Withdraw（提现）
  - 新增 `VirtualShortcut` 用于客户端签名场景
  - 新增 `WechatTrait::getWechatVirtualPaySignature()` 和 `getWechatVirtualSessionSignature()` 方法
  - `Wechat::success()` 支持 `['_action' => 'virtual']` 参数返回虚拟支付成功响应
  - 新增 `Wechat::URL_VIRTUAL` 常量（https://api.weixin.qq.com）

### Changed

- 移除所有 Provider 中未使用的 `mergeCommonPlugins` 方法 (#1173)

### Fixed

- 修复 `VirtualShortcut` 插件数组包含非 `PluginInterface` 实现的问题
- 修复虚拟支付测试用例缺少 `access_token` 参数的问题
- 移除测试文件中不必要的 `@internal` 和 `@coversNothing` 注解

---

同时更新 v3.8 升级指南，补充 beta.2 新增的微信小程序虚拟支付配置说明。