### PR TITLE
docs: release v3.8.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Unreleased
+## [v3.8.0-beta.3] - 2026-08-11
 
 ### Changed
 

--- a/web/docs/v3/upgrade/v3.8.md
+++ b/web/docs/v3/upgrade/v3.8.md
@@ -17,6 +17,7 @@
 
 - 检查是否有自行扩展相关插件，如果有，请对照 `breaking changes` 检查是否需要更改
 - 所有 Plugin 已迁移使用 Trait 方法代替 `Functions.php` 函数调用
+- v3.8.0-beta.3 起所有 Provider 的 `_url` payload 字段统一为前导 `/` 格式，各 Provider 的 base URL 常量已去掉尾部 `/`。如自定义插件中设置了 `_url` 字段，请遵循前导 `/` 约定（例如 `/v3/pay/transactions/native` 而非 `v3/pay/transactions/native`）
 
 ## 更改版本号
 


### PR DESCRIPTION
发布 v3.8.0-beta.3 预发布版本。

## 变更内容

本次发布包含自 v3.8.0-beta.2 以来的文档更新：

### Changed
- 统一所有 Provider 的 `_url` payload 字段为前导 `/` 格式，base URL 常量去掉尾部 `/` (#1183)

### Fixed
- 修复微信虚拟支付服务端 API 签名 uri 缺少前导 `/` 导致微信验签失败的问题 (#1182)

## 文档改动
- CHANGELOG.md: Unreleased → [v3.8.0-beta.3] - 2026-08-11
- web/docs/v3/upgrade/v3.8.md: 追加 beta.3 对自有插件开发者关于 `_url` 字段前导 `/` 约定的说明

合并后将打 tag `v3.8.0-beta.3` 并创建 GitHub Pre-release。